### PR TITLE
feat: add NLP rules package and dynamic rule loading

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,15 +32,20 @@
     "picocolors": "^1.1.1"
   },
   "peerDependencies": {
-    "@faircopy/rules-default": "workspace:*"
+    "@faircopy/rules-default": "workspace:*",
+    "@faircopy/rules-nlp": "workspace:*"
   },
   "peerDependenciesMeta": {
     "@faircopy/rules-default": {
+      "optional": true
+    },
+    "@faircopy/rules-nlp": {
       "optional": true
     }
   },
   "devDependencies": {
     "@faircopy/rules-default": "workspace:*",
+    "@faircopy/rules-nlp": "workspace:*",
     "@types/node": "^22.0.0",
     "tsup": "^8.4.0",
     "typescript": "^5.8.0"

--- a/packages/cli/src/commands/hook-stop.ts
+++ b/packages/cli/src/commands/hook-stop.ts
@@ -9,6 +9,7 @@ import {
 } from '@faircopy/core'
 import type { Diagnostic, ResolvedRule } from '@faircopy/core'
 import { formatPretty } from '../reporters/pretty.js'
+import { findRuleInRegistries, loadRuleRegistries } from '../rule-loader.js'
 
 interface StopHookInput {
   session_id?: string
@@ -75,19 +76,13 @@ export async function runHookStop(): Promise<void> {
   }
 
   // Load rules
-  let defaultRegistry: Map<string, import('@faircopy/core').Rule> = new Map()
-  try {
-    const mod = await import('@faircopy/rules-default') as { ruleRegistry: Map<string, import('@faircopy/core').Rule> }
-    defaultRegistry = mod.ruleRegistry
-  } catch {
-    process.exit(0) // No rules installed — nothing to enforce
-  }
+  const registries = await loadRuleRegistries(Object.keys(config.rules))
 
   const resolvedRules: ResolvedRule[] = []
   for (const [ruleId, ruleConfig] of Object.entries(config.rules)) {
     const { severity, options } = parseSeverity(ruleConfig)
     if (severity === 'off') continue
-    const rule = defaultRegistry.get(ruleId)
+    const rule = findRuleInRegistries(ruleId, registries)
     if (rule) resolvedRules.push({ rule, severity, options })
   }
 

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -9,6 +9,7 @@ import {
 } from '@faircopy/core'
 import type { Diagnostic, ResolvedRule } from '@faircopy/core'
 import { formatPretty } from '../reporters/pretty.js'
+import { findRuleInRegistries, loadRuleRegistries } from '../rule-loader.js'
 
 export interface LintOptions {
   config?: string
@@ -44,20 +45,13 @@ export async function runLint(files: string[], options: LintOptions): Promise<vo
     ? files.map(f => path.resolve(cwd, f))
     : await resolveFiles(config, cwd)
 
-  // Load the default rule registry if @faircopy/rules-default is installed.
-  let defaultRegistry: Map<string, import('@faircopy/core').Rule> = new Map()
-  try {
-    const mod = await import('@faircopy/rules-default') as { ruleRegistry: Map<string, import('@faircopy/core').Rule> }
-    defaultRegistry = mod.ruleRegistry
-  } catch {
-    // rules-default not installed — rules configured by bare name will be skipped
-  }
+  const registries = await loadRuleRegistries(Object.keys(config.rules))
 
   const resolvedRules: ResolvedRule[] = []
   for (const [ruleId, ruleConfig] of Object.entries(config.rules)) {
     const { severity, options: ruleOptions } = parseSeverity(ruleConfig)
     if (severity === 'off') continue
-    const rule = defaultRegistry.get(ruleId)
+    const rule = findRuleInRegistries(ruleId, registries)
     if (!rule) {
       process.stderr.write(`warn: unknown rule "${ruleId}" — skipped\n`)
       continue

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,1 +1,2 @@
 export type { LintOptions, FileResult } from './commands/lint.js'
+export { loadRuleRegistries, findRuleInRegistries, getPackageNameForRule, getRuleName } from './rule-loader.js'

--- a/packages/cli/src/rule-loader.ts
+++ b/packages/cli/src/rule-loader.ts
@@ -1,0 +1,75 @@
+import type { Rule } from '@faircopy/core'
+
+const REGISTRY_EXPORT_NAME = 'ruleRegistry'
+
+type RuleModule = {
+  ruleRegistry?: Map<string, Rule>
+}
+
+export interface LoadedRegistry {
+  packageName: string
+  registry: Map<string, Rule>
+}
+
+export async function loadRuleRegistries(ruleIds: string[]): Promise<LoadedRegistry[]> {
+  const packageNames = getRulePackageNames(ruleIds)
+  const registries = await Promise.all(packageNames.map(loadRegistry))
+  return registries.filter((registry): registry is LoadedRegistry => registry !== null)
+}
+
+function getRulePackageNames(ruleIds: string[]): string[] {
+  const packageNames = new Set<string>(['@faircopy/rules-default'])
+
+  for (const ruleId of ruleIds) {
+    const packageName = getPackageNameForRule(ruleId)
+    if (packageName) {
+      packageNames.add(packageName)
+    }
+  }
+
+  return [...packageNames]
+}
+
+export function getPackageNameForRule(ruleId: string): string | null {
+  if (!ruleId.includes('/')) return null
+
+  const slashIndex = ruleId.lastIndexOf('/')
+  if (slashIndex <= 0) return null
+
+  return ruleId.slice(0, slashIndex)
+}
+
+export function getRuleName(ruleId: string): string {
+  const slashIndex = ruleId.lastIndexOf('/')
+  return slashIndex === -1 ? ruleId : ruleId.slice(slashIndex + 1)
+}
+
+async function loadRegistry(packageName: string): Promise<LoadedRegistry | null> {
+  try {
+    const mod = await import(packageName) as RuleModule
+    if (mod[REGISTRY_EXPORT_NAME] instanceof Map) {
+      return {
+        packageName,
+        registry: mod[REGISTRY_EXPORT_NAME],
+      }
+    }
+  } catch {
+    return null
+  }
+
+  return null
+}
+
+export function findRuleInRegistries(ruleId: string, registries: LoadedRegistry[]): Rule | null {
+  const packageName = getPackageNameForRule(ruleId)
+  const ruleName = getRuleName(ruleId)
+
+  for (const { packageName: registryPackageName, registry } of registries) {
+    if (packageName !== null && registryPackageName !== packageName) continue
+
+    const rule = registry.get(ruleName)
+    if (rule) return rule
+  }
+
+  return null
+}

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -10,7 +10,7 @@ export default defineConfig([
     platform: 'node',
     target: 'node20',
     banner: { js: '#!/usr/bin/env node' },
-    external: ['@faircopy/core'],
+    external: ['@faircopy/core', '@faircopy/rules-default'],
     noExternal: ['cac', 'picocolors'],
   },
   {
@@ -20,6 +20,6 @@ export default defineConfig([
     sourcemap: true,
     platform: 'node',
     target: 'node20',
-    external: ['@faircopy/core'],
+    external: ['@faircopy/core', '@faircopy/rules-default'],
   },
 ])

--- a/packages/faircopy/package.json
+++ b/packages/faircopy/package.json
@@ -21,7 +21,8 @@
     "@faircopy/cli": "workspace:*",
     "@faircopy/config": "workspace:*",
     "@faircopy/core": "workspace:*",
-    "@faircopy/rules-default": "workspace:*"
+    "@faircopy/rules-default": "workspace:*",
+    "@faircopy/rules-nlp": "workspace:*"
   },
   "keywords": [
     "linter",

--- a/packages/rules-nlp/package.json
+++ b/packages/rules-nlp/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@faircopy/rules-nlp",
+  "version": "1.1.1",
+  "description": "Optional NLP-powered ruleset for faircopy using compromise",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "echo 'no tests yet'",
+    "prepublishOnly": "pnpm run build"
+  },
+  "dependencies": {
+    "@faircopy/core": "workspace:*",
+    "compromise": "^14.15.0"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "tsup": "^8.4.0",
+    "typescript": "^5.8.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "MIT",
+  "author": "omniaura",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/omniaura/faircopy"
+  }
+}

--- a/packages/rules-nlp/src/index.ts
+++ b/packages/rules-nlp/src/index.ts
@@ -1,0 +1,14 @@
+import type { Rule } from '@faircopy/core'
+import { noFilterWords } from './no-filter-words.js'
+import { noPassiveVoice } from './no-passive-voice.js'
+
+export { noFilterWords } from './no-filter-words.js'
+export { noPassiveVoice } from './no-passive-voice.js'
+export type { NoFilterWordsOptions } from './no-filter-words.js'
+export type { NoPassiveVoiceOptions } from './no-passive-voice.js'
+
+/** All NLP rules keyed by their rule ID. */
+export const ruleRegistry: Map<string, Rule> = new Map([
+  ['no-filter-words', noFilterWords as Rule],
+  ['no-passive-voice', noPassiveVoice as Rule],
+])

--- a/packages/rules-nlp/src/no-filter-words.ts
+++ b/packages/rules-nlp/src/no-filter-words.ts
@@ -1,0 +1,45 @@
+import type { Diagnostic, Rule, RuleInput } from '@faircopy/core'
+import { createDoc, getMatchOccurrences } from './utils.js'
+
+export interface NoFilterWordsOptions {
+  phrases?: string[]
+}
+
+const DEFAULT_PHRASES = [
+  'I think',
+  'it seems',
+  'basically',
+  'in order to',
+]
+
+export const noFilterWords: Rule<NoFilterWordsOptions> = {
+  id: 'no-filter-words',
+  description: 'Ban filter phrases that distance the claim from the reader',
+  defaults: { phrases: DEFAULT_PHRASES },
+  help: 'Filter phrases announce a perspective or pad the sentence instead of making the point. Delete the phrase or rewrite the sentence so the claim stands on its own.',
+
+  check({ text, sourceMap, options }: RuleInput<NoFilterWordsOptions>): Diagnostic[] {
+    const diagnostics: Diagnostic[] = []
+    const phrases = options.phrases?.length ? options.phrases : DEFAULT_PHRASES
+    const doc = createDoc(text)
+
+    for (const phrase of phrases) {
+      const matches = doc.match(phrase)
+      for (const occurrence of getMatchOccurrences(text, matches)) {
+        const start = sourceMap[occurrence.start]
+        const end = sourceMap[occurrence.end - 1]
+        if (start === undefined || end === undefined) continue
+
+        diagnostics.push({
+          ruleId: 'no-filter-words',
+          severity: 'error',
+          message: `remove "${occurrence.text.toLowerCase()}" — state the claim directly`,
+          range: { start, end: end + 1 },
+          help: noFilterWords.help,
+        })
+      }
+    }
+
+    return diagnostics
+  },
+}

--- a/packages/rules-nlp/src/no-passive-voice.ts
+++ b/packages/rules-nlp/src/no-passive-voice.ts
@@ -1,0 +1,52 @@
+import type { Diagnostic, Rule, RuleInput } from '@faircopy/core'
+import { createDoc, getMatchOccurrences } from './utils.js'
+
+export interface NoPassiveVoiceOptions {
+  allowedAuxiliaries?: string[]
+}
+
+const DEFAULT_ALLOWED_AUXILIARIES = ['is', 'are', 'was', 'were', 'be', 'been', 'being']
+
+export const noPassiveVoice: Rule<NoPassiveVoiceOptions> = {
+  id: 'no-passive-voice',
+  description: 'Flag likely passive-voice constructions using POS tagging patterns',
+  defaults: { allowedAuxiliaries: DEFAULT_ALLOWED_AUXILIARIES },
+  help: 'Passive voice often hides the actor and adds drag. Prefer naming who did the action unless the actor genuinely does not matter.',
+
+  check({ text, sourceMap, options }: RuleInput<NoPassiveVoiceOptions>): Diagnostic[] {
+    const diagnostics: Diagnostic[] = []
+    const auxiliaries = new Set((options.allowedAuxiliaries?.length ? options.allowedAuxiliaries : DEFAULT_ALLOWED_AUXILIARIES).map(value => value.toLowerCase()))
+    const doc = createDoc(text)
+    const matches = doc.match('(#Copula|#Auxiliary) #PastTense')
+
+    for (const occurrence of getMatchOccurrences(text, matches)) {
+      const words = occurrence.text.trim().split(/\s+/)
+      if (words.length < 2) continue
+      if (!auxiliaries.has(words[0]!.toLowerCase())) continue
+
+      const start = sourceMap[occurrence.start]
+      const end = sourceMap[occurrence.end - 1]
+      if (start === undefined || end === undefined) continue
+
+      diagnostics.push({
+        ruleId: 'no-passive-voice',
+        severity: 'warn',
+        message: `rewrite passive construction "${occurrence.text}" with a named actor`,
+        range: { start, end: end + 1 },
+        help: noPassiveVoice.help,
+      })
+    }
+
+    return dedupeDiagnostics(diagnostics)
+  },
+}
+
+function dedupeDiagnostics(diagnostics: Diagnostic[]): Diagnostic[] {
+  const seen = new Set<string>()
+  return diagnostics.filter((diagnostic) => {
+    const key = `${diagnostic.range.start}:${diagnostic.range.end}`
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}

--- a/packages/rules-nlp/src/types.ts
+++ b/packages/rules-nlp/src/types.ts
@@ -1,0 +1,17 @@
+export interface JsonOffsetTerm {
+  offset?: { start?: number; length?: number }
+}
+
+export interface JsonOffsetEntry {
+  text?: string
+  offset?: { start?: number; length?: number }
+  terms?: JsonOffsetTerm[]
+}
+
+export interface MatchView {
+  json(options?: unknown): JsonOffsetEntry[]
+}
+
+export interface DocView extends MatchView {
+  match(pattern: string): MatchView
+}

--- a/packages/rules-nlp/src/utils.ts
+++ b/packages/rules-nlp/src/utils.ts
@@ -1,0 +1,44 @@
+import nlp from 'compromise'
+import type { DocView, JsonOffsetEntry, JsonOffsetTerm, MatchView } from './types.js'
+
+export interface MatchOccurrence {
+  text: string
+  start: number
+  end: number
+}
+
+export function createDoc(text: string): DocView {
+  return nlp(text) as unknown as DocView
+}
+
+export function getMatchOccurrences(text: string, matches: MatchView): MatchOccurrence[] {
+  const json = matches.json({ offset: true, text: true, terms: { offset: true } }) as JsonOffsetEntry[]
+
+  return json.flatMap((entry) => {
+    const start = entry.offset?.start ?? entry.terms?.[0]?.offset?.start
+    const length = entry.offset?.length ?? sumTermLengths(entry.terms)
+
+    if (typeof start !== 'number' || typeof length !== 'number' || length <= 0) {
+      return []
+    }
+
+    return [{
+      text: entry.text ?? text.slice(start, start + length),
+      start,
+      end: start + length,
+    }]
+  })
+}
+
+function sumTermLengths(terms: JsonOffsetTerm[] | undefined): number | undefined {
+  if (!terms?.length) return undefined
+
+  let total = 0
+  for (const term of terms) {
+    const length = term.offset?.length
+    if (typeof length !== 'number') return undefined
+    total += length
+  }
+
+  return total
+}

--- a/packages/rules-nlp/tsconfig.json
+++ b/packages/rules-nlp/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": { "rootDir": "src", "outDir": "dist" },
+  "include": ["src"]
+}

--- a/packages/rules-nlp/tsup.config.ts
+++ b/packages/rules-nlp/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: { index: 'src/index.ts' },
+  format: 'esm',
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  platform: 'neutral',
+  target: 'es2020',
+  external: ['@faircopy/core', 'compromise'],
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,9 @@ importers:
       '@faircopy/rules-default':
         specifier: workspace:*
         version: link:../rules-default
+      '@faircopy/rules-nlp':
+        specifier: workspace:*
+        version: link:../rules-nlp
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.17
@@ -141,6 +144,9 @@ importers:
       '@faircopy/rules-default':
         specifier: workspace:*
         version: link:../rules-default
+      '@faircopy/rules-nlp':
+        specifier: workspace:*
+        version: link:../rules-nlp
 
   packages/plugin: {}
 
@@ -171,6 +177,25 @@ importers:
       '@faircopy/core':
         specifier: workspace:*
         version: link:../core
+    devDependencies:
+      '@types/bun':
+        specifier: latest
+        version: 1.3.13
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.1(jiti@2.6.1)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.8.0
+        version: 5.9.3
+
+  packages/rules-nlp:
+    dependencies:
+      '@faircopy/core':
+        specifier: workspace:*
+        version: link:../core
+      compromise:
+        specifier: ^14.15.0
+        version: 14.15.0
     devDependencies:
       '@types/bun':
         specifier: latest
@@ -850,6 +875,10 @@ packages:
   compare-func@2.0.0:
     resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
 
+  compromise@14.15.0:
+    resolution: {integrity: sha512-YEMv5JGWyqRJw5hdZqDVQF3MMlHA6TRiXreR8IYffk6xB7GA5p/8DeDzvg0Jy2tHNGpD+qJGl0+oJwA+5R/sVA==}
+    engines: {node: '>=12.0.0'}
+
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
@@ -929,6 +958,10 @@ packages:
 
   duplexer2@0.1.4:
     resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
+
+  efrt@2.7.0:
+    resolution: {integrity: sha512-/RInbCy1d4P6Zdfa+TMVsf/ufZVotat5hCw3QXmWtjU+3pFEOvOQ7ibo3aIxyCJw2leIeAMjmPj+1SLJiCpdrQ==}
+    engines: {node: '>=12.0.0'}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -1085,6 +1118,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  grad-school@0.0.5:
+    resolution: {integrity: sha512-rXunEHF9M9EkMydTBux7+IryYXEZinRk6g8OBOGDBzo/qWJjhTxy86i5q7lQYpCLHN8Sqv1XX3OIOc7ka2gtvQ==}
+    engines: {node: '>=8.0.0'}
 
   handlebars@4.7.9:
     resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
@@ -1801,6 +1838,9 @@ packages:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
+
+  suffix-thumb@5.0.2:
+    resolution: {integrity: sha512-I5PWXAFKx3FYnI9a+dQMWNqTxoRt6vdBdb0O+BJ1sxXCWtSoQCusc13E58f+9p4MYx/qCnEMkD5jac6K2j3dgA==}
 
   super-regex@1.1.0:
     resolution: {integrity: sha512-WHkws2ZflZe41zj6AolvvmaTrWds/VuyeYr9iPVv/oQeaIoVxMKaushfFWpOGDT+GuBrM/sVqF8KUCYQlSSTdQ==}
@@ -2570,6 +2610,12 @@ snapshots:
       array-ify: 1.0.0
       dot-prop: 5.3.0
 
+  compromise@14.15.0:
+    dependencies:
+      efrt: 2.7.0
+      grad-school: 0.0.5
+      suffix-thumb: 5.0.2
+
   confbox@0.1.8: {}
 
   config-chain@1.1.13:
@@ -2642,6 +2688,8 @@ snapshots:
   duplexer2@0.1.4:
     dependencies:
       readable-stream: 2.3.8
+
+  efrt@2.7.0: {}
 
   emoji-regex@10.6.0: {}
 
@@ -2839,6 +2887,8 @@ snapshots:
   graceful-fs@4.2.10: {}
 
   graceful-fs@4.2.11: {}
+
+  grad-school@0.0.5: {}
 
   handlebars@4.7.9:
     dependencies:
@@ -3458,6 +3508,8 @@ snapshots:
       pirates: 4.0.7
       tinyglobby: 0.2.16
       ts-interface-checker: 0.1.13
+
+  suffix-thumb@5.0.2: {}
 
   super-regex@1.1.0:
     dependencies:


### PR DESCRIPTION
## Summary
Add an optional @faircopy/rules-nlp package and update the CLI to load rule registries dynamically so NLP-powered rules can be configured and executed.

## Changes
- add a new publishable @faircopy/rules-nlp package powered by compromise
- introduce no-filter-words and no-passive-voice rules with shared NLP matching utilities
- add a CLI rule loader that resolves rule package names from configured rule IDs and imports their ruleRegistry
- update lint and hook-stop to use loaded registries instead of relying on a single built-in ruleset
- export rule-loader helpers from the CLI package and update package/build config to include the new package

## Why
This enables Faircopy to support semantic, NLP-based rules as optional extensions while keeping the CLI flexible enough to load rules from multiple packages.

## Testing
- build the workspace and confirm the new @faircopy/rules-nlp package is emitted correctly
- run faircopy lint with config entries such as @faircopy/rules-nlp/no-filter-words
- verify stop-hook linting still blocks on error-level diagnostics and can resolve external rule packages

<!-- emdash-issue-footer:start -->
Fixes #1
<!-- emdash-issue-footer:end -->