### PR TITLE
feat: agent compact reporting

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -22,7 +22,7 @@ faircopy --version
 | Flag | Default | Description |
 |---|---|---|
 | `--config <path>` | auto-detect | Explicit config file |
-| `--format <name>` | `pretty` | `pretty` / `json` / `github` / `compact` |
+| `--format <name>` | `pretty` | `pretty` / `json` / `github` / `compact` / `agent-compact` |
 | `--quiet` | false | Suppress warnings, only show errors |
 | `--max-warnings <n>` | unset | Exit 1 if warnings exceed n |
 | `--no-color` | auto | Disable ANSI colors |
@@ -42,3 +42,5 @@ faircopy --version
 **`json`** — JSON array of diagnostic objects
 
 **`compact`** — `path:line:col severity [ruleId] message`, one per line
+
+**`agent-compact`** — grouped, token-efficient output for coding agents. It includes line/column ranges, messages, help text, and normalized span snippets by default.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -7,7 +7,7 @@ const cli = cac('faircopy')
 cli
   .command('lint [...files]', 'Lint files or configured globs')
   .option('-c, --config <path>', 'Explicit config file path')
-  .option('--format <name>', 'Output format: pretty | json | github | compact', { default: 'pretty' })
+  .option('--format <name>', 'Output format: pretty | json | github | compact | agent-compact', { default: 'pretty' })
   .option('--quiet', 'Suppress warnings; only errors')
   .option('--max-warnings <n>', 'Exit 1 if warnings exceed n')
   .option('--no-color', 'Disable ANSI colors')

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -6,6 +6,8 @@ import {
   lintFile,
   parseSeverity,
   ConfigError,
+  formatAgentCompact,
+  offsetToLineCol,
 } from '@faircopy/core'
 import type { Diagnostic, ResolvedRule } from '@faircopy/core'
 import { formatPretty } from '../reporters/pretty.js'
@@ -91,6 +93,8 @@ export async function runLint(files: string[], options: LintOptions): Promise<vo
         process.stdout.write(`${filePath}:${line}:${col} ${d.severity} [${d.ruleId}] ${d.message}\n`)
       }
     }
+  } else if (fmt === 'agent-compact') {
+    process.stdout.write(formatAgentCompact(results, { ...config.output?.agentCompact, includeFile: true }) + '\n')
   } else {
     process.stdout.write(formatPretty(results, elapsed) + '\n')
   }
@@ -108,10 +112,4 @@ export async function runLint(files: string[], options: LintOptions): Promise<vo
   if (errorCount > 0 || (maxWarnings !== undefined && warnCount > maxWarnings)) {
     process.exit(1)
   }
-}
-
-function offsetToLineCol(source: string, offset: number): { line: number; col: number } {
-  const before = source.slice(0, offset)
-  const linesBefore = before.split('\n')
-  return { line: linesBefore.length, col: (linesBefore.at(-1) ?? '').length + 1 }
 }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -52,3 +52,28 @@ interface ExtractedText { text, sourceMap, meta? }
 ```
 
 See [types.ts](src/types.ts) for the full schema.
+
+## Agent Output
+
+`@faircopy/core/reporting` exposes reusable formatters for CLI, docs, and integrations:
+
+```ts
+import { formatAgentCompact, buildAgentJsonPayload } from '@faircopy/core/reporting'
+```
+
+`formatAgentCompact()` prints grouped diagnostics for coding agents. Snippets are enabled by default, character byte ranges are disabled by default, and both can be configured globally or per rule through `output.agentCompact`.
+
+```ts
+export default defineConfig({
+  output: {
+    agentCompact: {
+      snippets: 'all',
+      snippetChars: 140,
+      chars: false,
+      rules: {
+        'no-em-dash': { snippets: 'first' },
+      },
+    },
+  },
+})
+```

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,6 +7,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./reporting": {
+      "types": "./dist/reporting.d.ts",
+      "import": "./dist/reporting.js"
     }
   },
   "files": [

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,9 @@
 export type {
   FaircopyConfig,
+  FaircopyOutputConfig,
+  AgentCompactConfig,
+  AgentCompactSnippetMode,
+  AgentCompactRuleConfig,
   RuleConfig,
   Severity,
   Adapter,
@@ -18,3 +22,18 @@ export { resolveFiles } from './resolver.js'
 
 export { lintFile, parseSeverity } from './runner.js'
 export type { ResolvedRule } from './runner.js'
+
+export {
+  buildAgentJsonPayload,
+  collapseWhitespace,
+  collectDiagnosticReportItems,
+  formatAgentCompact,
+  offsetToLineCol,
+  truncate,
+} from './reporting.js'
+export type {
+  AgentCompactFormatOptions,
+  AgentJsonPayload,
+  DiagnosticReportItem,
+  ReportFileResult,
+} from './reporting.js'

--- a/packages/core/src/reporting.ts
+++ b/packages/core/src/reporting.ts
@@ -1,0 +1,171 @@
+import type {
+  AgentCompactConfig,
+  AgentCompactSnippetMode,
+  Diagnostic,
+  Severity,
+} from './types.js'
+
+export interface ReportFileResult {
+  filePath?: string
+  diagnostics: Diagnostic[]
+  source: string
+}
+
+export interface DiagnosticReportItem extends Diagnostic {
+  filePath?: string
+  startLine: number
+  startColumn: number
+  endLine: number
+  endColumn: number
+  snippet: string
+}
+
+export interface AgentJsonPayload {
+  tool: 'faircopy'
+  errorCount: number
+  warningCount: number
+  issueCount: number
+  errors: Array<{
+    filePath?: string
+    ruleId: string
+    severity: Severity
+    message: string
+    help: string | null
+    start: number
+    end: number
+    startLine: number
+    startColumn: number
+    endLine: number
+    endColumn: number
+    snippet: string
+  }>
+}
+
+export interface AgentCompactFormatOptions extends AgentCompactConfig {
+  includeFile?: boolean
+}
+
+export function formatAgentCompact(
+  results: ReportFileResult[],
+  options: AgentCompactFormatOptions = {}
+): string {
+  const items = collectDiagnosticReportItems(results)
+  if (items.length === 0) return 'faircopy errors=0 warnings=0'
+
+  const grouped = new Map<string, DiagnosticReportItem[]>()
+  for (const item of items) {
+    if (!grouped.has(item.ruleId)) grouped.set(item.ruleId, [])
+    grouped.get(item.ruleId)?.push(item)
+  }
+
+  const errorCount = items.filter(item => item.severity === 'error').length
+  const warnCount = items.filter(item => item.severity === 'warn').length
+  const lines = [`faircopy errors=${errorCount} warnings=${warnCount} rules=${grouped.size}`]
+
+  for (const [ruleId, ruleItems] of grouped.entries()) {
+    lines.push(`rule=${ruleId} count=${ruleItems.length} severity=${ruleItems[0]?.severity ?? 'error'}`)
+    ruleItems.forEach((item, index) => {
+      lines.push(formatAgentCompactLocation(item, index, options))
+      if (index === 0) {
+        lines.push(`  msg=${item.message}`)
+        if (item.help) lines.push(`  help=${item.help}`)
+      }
+    })
+  }
+
+  return lines.join('\n')
+}
+
+export function buildAgentJsonPayload(results: ReportFileResult[]): AgentJsonPayload {
+  const items = collectDiagnosticReportItems(results)
+  return {
+    tool: 'faircopy',
+    errorCount: items.filter(item => item.severity === 'error').length,
+    warningCount: items.filter(item => item.severity === 'warn').length,
+    issueCount: items.length,
+    errors: items.map(item => ({
+      filePath: item.filePath,
+      ruleId: item.ruleId,
+      severity: item.severity,
+      message: item.message,
+      help: item.help ?? null,
+      start: item.range.start,
+      end: item.range.end,
+      startLine: item.startLine,
+      startColumn: item.startColumn,
+      endLine: item.endLine,
+      endColumn: item.endColumn,
+      snippet: item.snippet,
+    })),
+  }
+}
+
+export function collectDiagnosticReportItems(results: ReportFileResult[]): DiagnosticReportItem[] {
+  return results.flatMap(result =>
+    result.diagnostics.map(diagnostic => {
+      const start = offsetToLineCol(result.source, diagnostic.range.start)
+      const endOffset = Math.max(diagnostic.range.start, diagnostic.range.end - 1)
+      const end = offsetToLineCol(result.source, endOffset)
+      return {
+        ...diagnostic,
+        filePath: result.filePath,
+        startLine: start.line,
+        startColumn: start.col,
+        endLine: end.line,
+        endColumn: end.col,
+        snippet: collapseWhitespace(result.source.slice(diagnostic.range.start, diagnostic.range.end)) || '(empty span)',
+      }
+    })
+  )
+}
+
+export function offsetToLineCol(source: string, offset: number): { line: number; col: number } {
+  const before = source.slice(0, offset)
+  const linesBefore = before.split('\n')
+  return { line: linesBefore.length, col: (linesBefore.at(-1) ?? '').length + 1 }
+}
+
+export function collapseWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim()
+}
+
+export function truncate(value: string, max = 180): string {
+  if (value.length <= max) return value
+  return `${value.slice(0, max - 3).trimEnd()}...`
+}
+
+function formatAgentCompactLocation(
+  item: DiagnosticReportItem,
+  index: number,
+  options: AgentCompactFormatOptions
+): string {
+  const linePrefix = options.includeFile && item.filePath
+    ? `${item.filePath}:${item.startLine}:${item.startColumn}-${item.endLine}:${item.endColumn}`
+    : `${item.startLine}:${item.startColumn}-${item.endLine}:${item.endColumn}`
+  let line = `  at=${linePrefix}`
+  if (shouldPrintChars(item.ruleId, options)) line += ` chars=${item.range.start}..${item.range.end}`
+  const snippetMode = getRuleSnippetMode(item.ruleId, options)
+  if (shouldPrintSnippet(snippetMode, index)) {
+    line += ` span=${JSON.stringify(resizeSnippet(item.snippet, item.ruleId, options))}`
+  }
+  return line
+}
+
+function getRuleSnippetMode(ruleId: string, options: AgentCompactFormatOptions): AgentCompactSnippetMode {
+  return options.rules?.[ruleId]?.snippets ?? options.snippets ?? 'all'
+}
+
+function shouldPrintSnippet(mode: AgentCompactSnippetMode, index: number): boolean {
+  if (mode === 'none') return false
+  if (mode === 'first') return index === 0
+  return true
+}
+
+function shouldPrintChars(ruleId: string, options: AgentCompactFormatOptions): boolean {
+  return options.rules?.[ruleId]?.chars ?? options.chars ?? false
+}
+
+function resizeSnippet(snippet: string, ruleId: string, options: AgentCompactFormatOptions): string {
+  const max = options.rules?.[ruleId]?.snippetChars ?? options.snippetChars ?? 140
+  return truncate(snippet, max)
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -11,11 +11,39 @@ export interface FaircopyConfig {
   noGitignore?: boolean
   /** Maximum concurrent file processing. Defaults to os.cpus().length. */
   concurrency?: number
+  /** Output formatter defaults. CLI flags may override the selected format. */
+  output?: FaircopyOutputConfig
 }
 
 export type RuleConfig =
   | Severity
   | [Severity, Record<string, unknown>]
+
+export interface FaircopyOutputConfig {
+  agentCompact?: AgentCompactConfig
+}
+
+export interface AgentCompactConfig {
+  /**
+   * Controls diagnostic snippets in agent-compact output.
+   * `all` is most useful for grep/edit loops; `first` is leaner for repeated hits.
+   */
+  snippets?: AgentCompactSnippetMode
+  /** Include byte-offset character ranges. Default false. */
+  chars?: boolean
+  /** Maximum normalized snippet length. Default 140. */
+  snippetChars?: number
+  /** Per-rule overrides keyed by rule id. */
+  rules?: Record<string, AgentCompactRuleConfig>
+}
+
+export type AgentCompactSnippetMode = 'none' | 'first' | 'all'
+
+export interface AgentCompactRuleConfig {
+  snippets?: AgentCompactSnippetMode
+  chars?: boolean
+  snippetChars?: number
+}
 
 export type Severity = 'off' | 'warn' | 'error'
 

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup'
 
 export default defineConfig({
-  entry: { index: 'src/index.ts' },
+  entry: { index: 'src/index.ts', reporting: 'src/reporting.ts' },
   format: 'esm',
   dts: true,
   sourcemap: true,


### PR DESCRIPTION
## Summary

- add reusable agent reporting helpers in `@faircopy/core/reporting`
- add `faircopy lint --format agent-compact`
- make snippets default to all diagnostics, with per-rule controls for snippets, snippet length, and optional `chars`
- keep byte char ranges off by default because agent harnesses usually act on file/line/column

## Verification

- `pnpm --filter @faircopy/core typecheck`
- `pnpm --filter @faircopy/core build`
- `pnpm --filter @faircopy/cli typecheck`
- `pnpm --filter @faircopy/cli build`
- `pnpm exec faircopy lint --format agent-compact` in `examples/empty-fixture` (expected exit 1 with fixture diagnostics)
