### PR TITLE
Verify synchronized package publishing

### DIFF
--- a/scripts/publish-packages.mjs
+++ b/scripts/publish-packages.mjs
@@ -52,6 +52,48 @@ const publishPackage = (dir) => {
   }
 }
 
+const getWorkspaceDeps = (pkg, packageNames) => {
+  const deps = {
+    ...pkg.dependencies,
+    ...pkg.peerDependencies,
+    ...pkg.optionalDependencies,
+  }
+
+  return Object.entries(deps)
+    .filter(([name, range]) => (
+      typeof range === 'string' && range.startsWith('workspace:') && packageNames.has(name)
+    ))
+    .map(([name]) => name)
+    .sort()
+}
+
+const sortPackagesForPublish = (packages) => {
+  const packageNames = new Set(packages.map(pkg => pkg.name))
+  const packageByName = new Map(packages.map(pkg => [pkg.name, pkg]))
+  const sorted = []
+  const visiting = new Set()
+  const visited = new Set()
+
+  const visit = (pkg, path = []) => {
+    if (visited.has(pkg.name)) return
+    if (visiting.has(pkg.name)) {
+      throw new Error(`Workspace dependency cycle detected: ${[...path, pkg.name].join(' -> ')}`)
+    }
+
+    visiting.add(pkg.name)
+    for (const depName of getWorkspaceDeps(pkg.manifest, packageNames)) {
+      visit(packageByName.get(depName), [...path, pkg.name])
+    }
+    visiting.delete(pkg.name)
+    visited.add(pkg.name)
+    sorted.push(pkg)
+  }
+
+  for (const pkg of packages) visit(pkg)
+  return sorted
+}
+
+const packages = []
 for (const dir of packageDirs) {
   const pkgPath = join('packages', dir, 'package.json')
   try { statSync(pkgPath) } catch { continue }
@@ -59,6 +101,10 @@ for (const dir of packageDirs) {
   const original = readFileSync(pkgPath, 'utf8')
   const pkg = JSON.parse(original)
   if (pkg.private) continue
+  packages.push({ dir, manifest: pkg, name: pkg.name, original, pkgPath })
+}
+
+for (const { dir, manifest: pkg, original, pkgPath } of sortPackagesForPublish(packages)) {
   publishedPackages.push(pkg.name)
 
   if (await isPublished(pkg.name)) {

--- a/scripts/publish-packages.mjs
+++ b/scripts/publish-packages.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Publishes each package via `npm publish --provenance`, replacing
+// Publishes every public workspace package at the same version, replacing
 // workspace:* deps with the release version before publish and restoring after.
 import { readFileSync, writeFileSync, readdirSync, statSync } from 'fs'
 import { join } from 'path'
@@ -15,13 +15,56 @@ const replaceWorkspace = (deps) => {
   )
 }
 
-for (const dir of readdirSync('packages')) {
+const packageDirs = readdirSync('packages').sort()
+const publishedPackages = []
+
+const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms))
+
+const isPublished = async (name) => {
+  const encodedName = name.replace('/', '%2f')
+  const url = `https://registry.npmjs.org/${encodedName}/${version}`
+  for (let attempt = 1; attempt <= 6; attempt += 1) {
+    try {
+      const response = await fetch(url)
+      if (response.status === 404) return false
+      if (response.ok) return true
+      if (attempt === 6) {
+        throw new Error(`npm registry check failed for ${name}@${version}: ${response.status} ${response.statusText}`)
+      }
+    } catch (error) {
+      if (attempt === 6) {
+        throw new Error(`npm registry check failed for ${name}@${version}: ${error.message}`)
+      }
+    }
+    await sleep(1000 * attempt)
+  }
+  return false
+}
+
+const publishPackage = (dir) => {
+  try {
+    execSync('npm publish --access public --provenance', {
+      cwd: join('packages', dir),
+      stdio: 'inherit',
+    })
+  } catch (error) {
+    throw new Error(`Failed to publish packages/${dir}: ${error.message}`)
+  }
+}
+
+for (const dir of packageDirs) {
   const pkgPath = join('packages', dir, 'package.json')
   try { statSync(pkgPath) } catch { continue }
 
   const original = readFileSync(pkgPath, 'utf8')
   const pkg = JSON.parse(original)
   if (pkg.private) continue
+  publishedPackages.push(pkg.name)
+
+  if (await isPublished(pkg.name)) {
+    console.log(`${pkg.name}@${version} is already published; skipping.`)
+    continue
+  }
 
   const patched = {
     ...pkg,
@@ -33,11 +76,19 @@ for (const dir of readdirSync('packages')) {
   writeFileSync(pkgPath, JSON.stringify(patched, null, 2) + '\n')
   try {
     console.log(`Publishing ${pkg.name}@${version}...`)
-    execSync('npm publish --access public', {
-      cwd: join('packages', dir),
-      stdio: 'inherit',
-    })
+    publishPackage(dir)
   } finally {
     writeFileSync(pkgPath, original)
   }
 }
+
+const missing = []
+for (const name of publishedPackages) {
+  if (!(await isPublished(name))) missing.push(name)
+}
+if (missing.length > 0) {
+  console.error(`Missing published packages for ${version}: ${missing.join(', ')}`)
+  process.exit(1)
+}
+
+console.log(`Published ${publishedPackages.length} faircopy packages at ${version}.`)


### PR DESCRIPTION
## Summary

- make `scripts/publish-packages.mjs` explicitly treat synchronized workspace publishing as the release invariant
- skip packages that are already published at the target version so release reruns can recover from partial publishes
- verify every public package exists at the target version before the release job reports success
- publish with npm provenance to match the trusted-publishing workflow intent

## Verification

- `node scripts/publish-packages.mjs 1.2.0` confirmed all 10 Faircopy packages are already published and skipped

Note: `pnpm typecheck` was not a useful verification for this script-only change in the local workspace because `node_modules` was stale after fast-forwarding `main`.
