### PR TITLE
feat: add nlp copy rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ Install the plugin to get a stop hook (blocks the turn if lint errors are found)
 | `no-weasel-words` | `error` | Ban `actually`, `truly`, `really`, `literally` |
 | `no-rhetorical-scaffolding` | `error` | Ban `X is Y, not Z` and `Without X / With X` patterns |
 
+Optional NLP rules live in `@faircopy/rules-nlp` and are configured with package-qualified IDs:
+
+| Rule | Description |
+|---|---|
+| `@faircopy/rules-nlp/no-filter-words` | Ban filter phrases like `I think` and `it seems` |
+| `@faircopy/rules-nlp/no-passive-voice` | Flag likely passive-voice constructions |
+| `@faircopy/rules-nlp/no-weak-modals` | Flag hedged modal claims like `can help` and `might improve` |
+| `@faircopy/rules-nlp/no-stacked-adjectives` | Flag noun phrases with multiple adjectives before the noun |
+| `@faircopy/rules-nlp/no-nominalized-phrases` | Flag nominalized `X of Y` phrases like `optimization of onboarding` |
+
 ## Packages
 
 | Package | Purpose |
@@ -79,6 +89,7 @@ Install the plugin to get a stop hook (blocks the turn if lint errors are found)
 | [`@faircopy/core`](packages/core) | Engine: types, config loader, file resolver, rule runner |
 | [`@faircopy/astro`](packages/astro) | Astro adapter |
 | [`@faircopy/rules-default`](packages/rules-default) | Default ruleset |
+| [`@faircopy/rules-nlp`](packages/rules-nlp) | Optional NLP-powered ruleset |
 | [`@faircopy/config`](packages/config) | `defineConfig()` helper |
 | [`@faircopy/plugin`](packages/plugin) | Claude Code plugin |
 

--- a/packages/rules-nlp/README.md
+++ b/packages/rules-nlp/README.md
@@ -1,0 +1,28 @@
+# @faircopy/rules-nlp
+
+Optional NLP-powered ruleset for faircopy using `compromise`.
+
+```sh
+npm i -D @faircopy/rules-nlp
+```
+
+Configure rules with the package-qualified rule ID:
+
+```ts
+rules: {
+  '@faircopy/rules-nlp/no-passive-voice': 'warn',
+  '@faircopy/rules-nlp/no-weak-modals': 'warn',
+  '@faircopy/rules-nlp/no-stacked-adjectives': 'warn',
+  '@faircopy/rules-nlp/no-nominalized-phrases': 'warn',
+}
+```
+
+## Rules
+
+| Rule | Description |
+|---|---|
+| `no-filter-words` | Ban filter phrases like `I think` and `it seems` |
+| `no-passive-voice` | Flag likely passive-voice constructions |
+| `no-weak-modals` | Flag hedged modal claims like `can help` and `might improve` |
+| `no-stacked-adjectives` | Flag noun phrases with multiple adjectives before the noun |
+| `no-nominalized-phrases` | Flag nominalized `X of Y` phrases like `optimization of onboarding` |

--- a/packages/rules-nlp/package.json
+++ b/packages/rules-nlp/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "tsup",
     "typecheck": "tsc --noEmit",
-    "test": "echo 'no tests yet'",
+    "test": "pnpm run build && node --test test/*.test.mjs",
     "prepublishOnly": "pnpm run build"
   },
   "dependencies": {

--- a/packages/rules-nlp/src/index.ts
+++ b/packages/rules-nlp/src/index.ts
@@ -1,14 +1,26 @@
 import type { Rule } from '@faircopy/core'
 import { noFilterWords } from './no-filter-words.js'
+import { noNominalizedPhrases } from './no-nominalized-phrases.js'
 import { noPassiveVoice } from './no-passive-voice.js'
+import { noStackedAdjectives } from './no-stacked-adjectives.js'
+import { noWeakModals } from './no-weak-modals.js'
 
 export { noFilterWords } from './no-filter-words.js'
+export { noNominalizedPhrases } from './no-nominalized-phrases.js'
 export { noPassiveVoice } from './no-passive-voice.js'
+export { noStackedAdjectives } from './no-stacked-adjectives.js'
+export { noWeakModals } from './no-weak-modals.js'
 export type { NoFilterWordsOptions } from './no-filter-words.js'
+export type { NoNominalizedPhrasesOptions } from './no-nominalized-phrases.js'
 export type { NoPassiveVoiceOptions } from './no-passive-voice.js'
+export type { NoStackedAdjectivesOptions } from './no-stacked-adjectives.js'
+export type { NoWeakModalsOptions } from './no-weak-modals.js'
 
 /** All NLP rules keyed by their rule ID. */
 export const ruleRegistry: Map<string, Rule> = new Map([
   ['no-filter-words', noFilterWords as Rule],
+  ['no-nominalized-phrases', noNominalizedPhrases as Rule],
   ['no-passive-voice', noPassiveVoice as Rule],
+  ['no-stacked-adjectives', noStackedAdjectives as Rule],
+  ['no-weak-modals', noWeakModals as Rule],
 ])

--- a/packages/rules-nlp/src/no-nominalized-phrases.ts
+++ b/packages/rules-nlp/src/no-nominalized-phrases.ts
@@ -1,0 +1,61 @@
+import type { Diagnostic, Rule, RuleInput } from '@faircopy/core'
+import { createDoc, getMatchOccurrences, getOccurrenceRange } from './utils.js'
+
+export interface NoNominalizedPhrasesOptions {
+  suffixes?: string[]
+  allowedWords?: string[]
+}
+
+const DEFAULT_SUFFIXES = ['tion', 'sion', 'ment', 'ance', 'ence', 'ity']
+const DEFAULT_ALLOWED_WORDS = [
+  'accessibility',
+  'availability',
+  'capacity',
+  'community',
+  'identity',
+  'opportunity',
+  'privacy',
+  'quality',
+  'reliability',
+  'security',
+]
+
+export const noNominalizedPhrases: Rule<NoNominalizedPhrasesOptions> = {
+  id: 'no-nominalized-phrases',
+  description: 'Flag nominalized "X of Y" phrases that hide the action in a noun',
+  defaults: { suffixes: DEFAULT_SUFFIXES, allowedWords: DEFAULT_ALLOWED_WORDS },
+  help: 'Nominalized phrases bury the action. Rewrite the phrase with a verb so the sentence says who does what.',
+
+  check({ text, sourceMap, options }: RuleInput<NoNominalizedPhrasesOptions>): Diagnostic[] {
+    const diagnostics: Diagnostic[] = []
+    const suffixes = options.suffixes?.length ? options.suffixes : DEFAULT_SUFFIXES
+    const allowedWords = new Set((options.allowedWords?.length ? options.allowedWords : DEFAULT_ALLOWED_WORDS).map(value => value.toLowerCase()))
+    const suffixPattern = suffixes.map(escapeRegex).join('|')
+    if (!suffixPattern) return diagnostics
+
+    const doc = createDoc(text)
+    const matches = doc.match(`/[a-z]+(${suffixPattern})/ of .`)
+
+    for (const occurrence of getMatchOccurrences(text, matches)) {
+      const nominalization = occurrence.text.trim().split(/\s+/)[0]?.toLowerCase()
+      if (!nominalization || allowedWords.has(nominalization)) continue
+
+      const range = getOccurrenceRange(sourceMap, occurrence)
+      if (!range) continue
+
+      diagnostics.push({
+        ruleId: 'no-nominalized-phrases',
+        severity: 'warn',
+        message: `rewrite "${occurrence.text}" with a verb`,
+        range,
+        help: noNominalizedPhrases.help,
+      })
+    }
+
+    return diagnostics
+  },
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}

--- a/packages/rules-nlp/src/no-stacked-adjectives.ts
+++ b/packages/rules-nlp/src/no-stacked-adjectives.ts
@@ -1,0 +1,37 @@
+import type { Diagnostic, Rule, RuleInput } from '@faircopy/core'
+import { createDoc, getMatchOccurrences, getOccurrenceRange } from './utils.js'
+
+export interface NoStackedAdjectivesOptions {
+  allowedPhrases?: string[]
+}
+
+export const noStackedAdjectives: Rule<NoStackedAdjectivesOptions> = {
+  id: 'no-stacked-adjectives',
+  description: 'Flag noun phrases with multiple adjectives before the noun',
+  defaults: { allowedPhrases: [] },
+  help: 'Stacked adjectives make copy feel generic. Keep the one descriptor that earns its place or replace the phrase with concrete evidence.',
+
+  check({ text, sourceMap, options }: RuleInput<NoStackedAdjectivesOptions>): Diagnostic[] {
+    const diagnostics: Diagnostic[] = []
+    const allowedPhrases = new Set((options.allowedPhrases ?? []).map(value => value.toLowerCase()))
+    const doc = createDoc(text)
+    const matches = doc.match('#Adjective #Adjective+ #Noun')
+
+    for (const occurrence of getMatchOccurrences(text, matches)) {
+      if (allowedPhrases.has(occurrence.text.toLowerCase())) continue
+
+      const range = getOccurrenceRange(sourceMap, occurrence)
+      if (!range) continue
+
+      diagnostics.push({
+        ruleId: 'no-stacked-adjectives',
+        severity: 'warn',
+        message: `cut stacked adjectives in "${occurrence.text}"`,
+        range,
+        help: noStackedAdjectives.help,
+      })
+    }
+
+    return diagnostics
+  },
+}

--- a/packages/rules-nlp/src/no-weak-modals.ts
+++ b/packages/rules-nlp/src/no-weak-modals.ts
@@ -1,0 +1,57 @@
+import type { Diagnostic, Rule, RuleInput } from '@faircopy/core'
+import { createDoc, getMatchOccurrences, getOccurrenceRange } from './utils.js'
+
+export interface NoWeakModalsOptions {
+  modals?: string[]
+  verbs?: string[]
+}
+
+const DEFAULT_MODALS = ['can', 'could', 'may', 'might']
+const DEFAULT_VERBS = [
+  'boost',
+  'drive',
+  'enable',
+  'help',
+  'improve',
+  'increase',
+  'make',
+  'reduce',
+  'support',
+  'transform',
+  'unlock',
+]
+
+export const noWeakModals: Rule<NoWeakModalsOptions> = {
+  id: 'no-weak-modals',
+  description: 'Flag hedged modal claims like "can help" and "might improve"',
+  defaults: { modals: DEFAULT_MODALS, verbs: DEFAULT_VERBS },
+  help: 'Hedged modal claims sound tentative. Replace them with the outcome, capability, or proof you can stand behind.',
+
+  check({ text, sourceMap, options }: RuleInput<NoWeakModalsOptions>): Diagnostic[] {
+    const diagnostics: Diagnostic[] = []
+    const modals = new Set((options.modals?.length ? options.modals : DEFAULT_MODALS).map(value => value.toLowerCase()))
+    const verbs = new Set((options.verbs?.length ? options.verbs : DEFAULT_VERBS).map(value => value.toLowerCase()))
+    const doc = createDoc(text)
+    const matches = doc.match('#Modal #Adverb? #Verb')
+
+    for (const occurrence of getMatchOccurrences(text, matches)) {
+      const words = occurrence.text.trim().split(/\s+/)
+      const modal = words[0]?.toLowerCase()
+      const verb = words[words.length - 1]?.toLowerCase()
+      if (!modal || !verb || !modals.has(modal) || !verbs.has(verb)) continue
+
+      const range = getOccurrenceRange(sourceMap, occurrence)
+      if (!range) continue
+
+      diagnostics.push({
+        ruleId: 'no-weak-modals',
+        severity: 'warn',
+        message: `replace "${occurrence.text.toLowerCase()}" with a direct claim`,
+        range,
+        help: noWeakModals.help,
+      })
+    }
+
+    return diagnostics
+  },
+}

--- a/packages/rules-nlp/src/utils.ts
+++ b/packages/rules-nlp/src/utils.ts
@@ -1,4 +1,5 @@
 import nlp from 'compromise'
+import type { Diagnostic } from '@faircopy/core'
 import type { DocView, JsonOffsetEntry, JsonOffsetTerm, MatchView } from './types.js'
 
 export interface MatchOccurrence {
@@ -28,6 +29,14 @@ export function getMatchOccurrences(text: string, matches: MatchView): MatchOccu
       end: start + length,
     }]
   })
+}
+
+export function getOccurrenceRange(sourceMap: number[], occurrence: MatchOccurrence): Diagnostic['range'] | null {
+  const start = sourceMap[occurrence.start]
+  const end = sourceMap[occurrence.end - 1]
+  if (start === undefined || end === undefined) return null
+
+  return { start, end: end + 1 }
 }
 
 function sumTermLengths(terms: JsonOffsetTerm[] | undefined): number | undefined {

--- a/packages/rules-nlp/test/rules.test.mjs
+++ b/packages/rules-nlp/test/rules.test.mjs
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  noNominalizedPhrases,
+  noStackedAdjectives,
+  noWeakModals,
+  ruleRegistry,
+} from '../dist/index.js'
+
+function run(rule, text, options = {}) {
+  return rule.check({
+    text,
+    sourceMap: Array.from({ length: text.length }, (_, index) => index),
+    filePath: 'fixture.astro',
+    options,
+  })
+}
+
+test('no-weak-modals flags hedged helper claims but allows concrete capabilities', () => {
+  const text = 'This can help teams grow. You can export CSV.'
+  const diagnostics = run(noWeakModals, text)
+
+  assert.equal(diagnostics.length, 1)
+  assert.equal(diagnostics[0].ruleId, 'no-weak-modals')
+  assert.deepEqual(diagnostics[0].range, { start: 5, end: 13 })
+})
+
+test('no-stacked-adjectives flags adjective-heavy noun phrases', () => {
+  const text = 'Powerful intuitive collaborative workflows help teams move.'
+  const diagnostics = run(noStackedAdjectives, text)
+
+  assert.equal(diagnostics.length, 1)
+  assert.equal(diagnostics[0].ruleId, 'no-stacked-adjectives')
+  assert.match(diagnostics[0].message, /Powerful intuitive collaborative workflows/)
+})
+
+test('no-stacked-adjectives respects allowed phrases', () => {
+  const text = 'Powerful intuitive collaborative workflows help teams move.'
+  const diagnostics = run(noStackedAdjectives, text, {
+    allowedPhrases: ['powerful intuitive collaborative workflows'],
+  })
+
+  assert.equal(diagnostics.length, 0)
+})
+
+test('no-nominalized-phrases flags nominalized of-phrases', () => {
+  const text = 'Optimization of onboarding improves activation.'
+  const diagnostics = run(noNominalizedPhrases, text)
+
+  assert.equal(diagnostics.length, 1)
+  assert.equal(diagnostics[0].ruleId, 'no-nominalized-phrases')
+  assert.deepEqual(diagnostics[0].range, { start: 0, end: 26 })
+})
+
+test('no-nominalized-phrases allows configured concrete nouns', () => {
+  const text = 'Security of customer data comes first.'
+  const diagnostics = run(noNominalizedPhrases, text)
+
+  assert.equal(diagnostics.length, 0)
+})
+
+test('rule registry exposes all nlp rules', () => {
+  assert.ok(ruleRegistry.has('no-filter-words'))
+  assert.ok(ruleRegistry.has('no-passive-voice'))
+  assert.ok(ruleRegistry.has('no-weak-modals'))
+  assert.ok(ruleRegistry.has('no-stacked-adjectives'))
+  assert.ok(ruleRegistry.has('no-nominalized-phrases'))
+})


### PR DESCRIPTION
## Summary

- add three optional `@faircopy/rules-nlp` rules: `no-weak-modals`, `no-stacked-adjectives`, and `no-nominalized-phrases`
- register and export the new rules from the NLP ruleset
- add package docs and Node-based tests for the NLP ruleset

## Validation

- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm --filter @faircopy/rules-nlp pack --dry-run`
