### PR TITLE
feat(rules-nlp): flag empty transformation claims

### DIFF
--- a/packages/rules-nlp/README.md
+++ b/packages/rules-nlp/README.md
@@ -12,6 +12,7 @@ Load the ruleset once, then configure rules with bare rule IDs:
 rulesets: ['@faircopy/rules-nlp'],
 rules: {
   'no-filter-words': 'warn',
+  'no-empty-transformation-claims': 'warn',
   'no-passive-voice': 'warn',
   'no-weak-modals': 'warn',
   'no-stacked-adjectives': 'warn',
@@ -25,6 +26,7 @@ Package-qualified IDs like `@faircopy/rules-nlp/no-passive-voice` still work and
 
 | Rule | Description |
 |---|---|
+| `no-empty-transformation-claims` | Flag broad transformation cliches like `transform the way teams work` |
 | `no-filter-words` | Ban filter phrases like `I think` and `it seems` |
 | `no-passive-voice` | Flag likely passive-voice constructions |
 | `no-weak-modals` | Flag hedged modal claims like `can help` and `might improve` |

--- a/packages/rules-nlp/src/index.ts
+++ b/packages/rules-nlp/src/index.ts
@@ -1,16 +1,19 @@
 import type { Rule } from '@faircopy/core'
 import { noFilterWords } from './no-filter-words.js'
+import { noEmptyTransformationClaims } from './no-empty-transformation-claims.js'
 import { noNominalizedPhrases } from './no-nominalized-phrases.js'
 import { noPassiveVoice } from './no-passive-voice.js'
 import { noStackedAdjectives } from './no-stacked-adjectives.js'
 import { noWeakModals } from './no-weak-modals.js'
 
 export { noFilterWords } from './no-filter-words.js'
+export { noEmptyTransformationClaims } from './no-empty-transformation-claims.js'
 export { noNominalizedPhrases } from './no-nominalized-phrases.js'
 export { noPassiveVoice } from './no-passive-voice.js'
 export { noStackedAdjectives } from './no-stacked-adjectives.js'
 export { noWeakModals } from './no-weak-modals.js'
 export type { NoFilterWordsOptions } from './no-filter-words.js'
+export type { NoEmptyTransformationClaimsOptions } from './no-empty-transformation-claims.js'
 export type { NoNominalizedPhrasesOptions } from './no-nominalized-phrases.js'
 export type { NoPassiveVoiceOptions } from './no-passive-voice.js'
 export type { NoStackedAdjectivesOptions } from './no-stacked-adjectives.js'
@@ -18,6 +21,7 @@ export type { NoWeakModalsOptions } from './no-weak-modals.js'
 
 /** All NLP rules keyed by their rule ID. */
 export const ruleRegistry: Map<string, Rule> = new Map([
+  ['no-empty-transformation-claims', noEmptyTransformationClaims as Rule],
   ['no-filter-words', noFilterWords as Rule],
   ['no-nominalized-phrases', noNominalizedPhrases as Rule],
   ['no-passive-voice', noPassiveVoice as Rule],

--- a/packages/rules-nlp/src/no-empty-transformation-claims.ts
+++ b/packages/rules-nlp/src/no-empty-transformation-claims.ts
@@ -1,0 +1,64 @@
+import type { Diagnostic, Rule, RuleInput } from '@faircopy/core'
+
+export interface NoEmptyTransformationClaimsOptions {
+  allowedPhrases?: string[]
+}
+
+interface Pattern {
+  re: RegExp
+  message: string
+}
+
+const PATTERNS: Pattern[] = [
+  {
+    re: /\b(?:transform(?:s|ed|ing)?|chang(?:e|es|ed|ing)|reimagin(?:e|es|ed|ing)|revolutioniz(?:e|es|ed|ing))\s+the\s+way\s+(?:you|your\s+team|teams|companies|businesses|people)\s+(?:work|build|sell|operate|collaborate|communicate|create|grow|ship|scale|learn|manage)\b/gi,
+    message: 'replace empty transformation claim with a concrete outcome',
+  },
+  {
+    re: /\bunlock\s+(?:your|their|team|teams'|your\s+team's|the\s+team's|the\s+full)\s+(?:potential|productivity|growth|creativity|efficiency)\b/gi,
+    message: 'replace empty unlock claim with the specific benefit',
+  },
+  {
+    re: /\btake\s+(?:your|their|team|teams'|your\s+team's|the\s+team's)?\s*(?:productivity|workflow|workflows|growth|collaboration|business|operations|process|processes)\s+to\s+the\s+next\s+level\b/gi,
+    message: 'replace next-level claim with measurable value',
+  },
+]
+
+export const noEmptyTransformationClaims: Rule<NoEmptyTransformationClaimsOptions> = {
+  id: 'no-empty-transformation-claims',
+  description: 'Flag broad transformation claims that do not name a concrete outcome',
+  defaults: { allowedPhrases: [] },
+  help: 'Transformation cliches promise a feeling instead of a result. Replace them with the specific workflow, metric, or customer outcome the product changes.',
+
+  check({ text, sourceMap, options }: RuleInput<NoEmptyTransformationClaimsOptions>): Diagnostic[] {
+    const diagnostics: Diagnostic[] = []
+    const allowedPhrases = new Set((options.allowedPhrases ?? []).map(value => normalize(value)))
+
+    for (const pattern of PATTERNS) {
+      const re = new RegExp(pattern.re.source, pattern.re.flags)
+      let match: RegExpExecArray | null
+      while ((match = re.exec(text)) !== null) {
+        const phrase = match[0]
+        if (allowedPhrases.has(normalize(phrase))) continue
+
+        const start = sourceMap[match.index]
+        const end = sourceMap[match.index + phrase.length - 1]
+        if (start === undefined || end === undefined) continue
+
+        diagnostics.push({
+          ruleId: 'no-empty-transformation-claims',
+          severity: 'warn',
+          message: `${pattern.message}: "${phrase}"`,
+          range: { start, end: end + 1 },
+          help: noEmptyTransformationClaims.help,
+        })
+      }
+    }
+
+    return diagnostics
+  },
+}
+
+function normalize(value: string): string {
+  return value.toLowerCase().replace(/\s+/g, ' ').trim()
+}

--- a/packages/rules-nlp/test/rules.test.mjs
+++ b/packages/rules-nlp/test/rules.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import {
+  noEmptyTransformationClaims,
   noNominalizedPhrases,
   noStackedAdjectives,
   noWeakModals,
@@ -15,6 +16,43 @@ function run(rule, text, options = {}) {
     options,
   })
 }
+
+test('no-empty-transformation-claims flags broad transformation cliches', () => {
+  const text = 'Faircopy transforms the way teams work. It also reduces review time by 30%.'
+  const diagnostics = run(noEmptyTransformationClaims, text)
+
+  assert.equal(diagnostics.length, 1)
+  assert.equal(diagnostics[0].ruleId, 'no-empty-transformation-claims')
+  assert.deepEqual(diagnostics[0].range, { start: 9, end: 38 })
+  assert.match(diagnostics[0].message, /concrete outcome/)
+})
+
+test('no-empty-transformation-claims flags next-level and unlock claims', () => {
+  const text = 'Unlock your productivity. Take your workflow to the next level.'
+  const diagnostics = run(noEmptyTransformationClaims, text)
+
+  assert.equal(diagnostics.length, 2)
+  assert.deepEqual(diagnostics.map(diagnostic => diagnostic.range), [
+    { start: 0, end: 24 },
+    { start: 26, end: 62 },
+  ])
+})
+
+test('no-empty-transformation-claims avoids concrete transformation language', () => {
+  const text = 'Convert support tickets into prioritized Jira issues in one click.'
+  const diagnostics = run(noEmptyTransformationClaims, text)
+
+  assert.equal(diagnostics.length, 0)
+})
+
+test('no-empty-transformation-claims respects allowed phrases', () => {
+  const text = 'Faircopy transforms the way teams work.'
+  const diagnostics = run(noEmptyTransformationClaims, text, {
+    allowedPhrases: ['transforms the way teams work'],
+  })
+
+  assert.equal(diagnostics.length, 0)
+})
 
 test('no-weak-modals flags hedged helper claims but allows concrete capabilities', () => {
   const text = 'This can help teams grow. You can export CSV.'
@@ -60,6 +98,7 @@ test('no-nominalized-phrases allows configured concrete nouns', () => {
 })
 
 test('rule registry exposes all nlp rules', () => {
+  assert.ok(ruleRegistry.has('no-empty-transformation-claims'))
   assert.ok(ruleRegistry.has('no-filter-words'))
   assert.ok(ruleRegistry.has('no-passive-voice'))
   assert.ok(ruleRegistry.has('no-weak-modals'))


### PR DESCRIPTION
## Summary
- adds `no-empty-transformation-claims` to `@faircopy/rules-nlp`
- flags narrow transformation cliches: `transform the way teams work`, `unlock your productivity`, and `take your workflow to the next level`
- documents and tests the rule, including allowed phrase and concrete-copy non-match cases

## Tests
- `./node_modules/.bin/tsc -p packages/rules-nlp/tsconfig.json --noEmit`
- `cd packages/rules-nlp && ../../node_modules/.bin/tsup && node --test test/*.test.mjs`

## Notes
- `pnpm` is not installed in this container, so I ran the underlying package commands directly.
