### PR TITLE
feat: add expletive opener NLP rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Optional NLP rules live in `@faircopy/rules-nlp`. Load the ruleset once to confi
 export default defineConfig({
   rulesets: ['@faircopy/rules-nlp'],
   rules: {
+    'no-expletive-openers': 'warn',
     'no-filter-words': 'warn',
     'no-passive-voice': 'warn',
     'no-weak-modals': 'warn',
@@ -89,6 +90,7 @@ Use a package-qualified ID if two loaded rulesets expose the same bare rule name
 
 | Rule | Description |
 |---|---|
+| `@faircopy/rules-nlp/no-expletive-openers` | Flag sentence openings like `There are` and `It is` |
 | `@faircopy/rules-nlp/no-filter-words` | Ban filter phrases like `I think` and `it seems` |
 | `@faircopy/rules-nlp/no-passive-voice` | Flag likely passive-voice constructions |
 | `@faircopy/rules-nlp/no-weak-modals` | Flag hedged modal claims like `can help` and `might improve` |

--- a/packages/rules-nlp/README.md
+++ b/packages/rules-nlp/README.md
@@ -11,6 +11,7 @@ Load the ruleset once, then configure rules with bare rule IDs:
 ```ts
 rulesets: ['@faircopy/rules-nlp'],
 rules: {
+  'no-expletive-openers': 'warn',
   'no-filter-words': 'warn',
   'no-passive-voice': 'warn',
   'no-weak-modals': 'warn',
@@ -25,6 +26,7 @@ Package-qualified IDs like `@faircopy/rules-nlp/no-passive-voice` still work and
 
 | Rule | Description |
 |---|---|
+| `no-expletive-openers` | Flag sentence openings like `There are` and `It is` |
 | `no-filter-words` | Ban filter phrases like `I think` and `it seems` |
 | `no-passive-voice` | Flag likely passive-voice constructions |
 | `no-weak-modals` | Flag hedged modal claims like `can help` and `might improve` |

--- a/packages/rules-nlp/src/index.ts
+++ b/packages/rules-nlp/src/index.ts
@@ -1,15 +1,18 @@
 import type { Rule } from '@faircopy/core'
+import { noExpletiveOpeners } from './no-expletive-openers.js'
 import { noFilterWords } from './no-filter-words.js'
 import { noNominalizedPhrases } from './no-nominalized-phrases.js'
 import { noPassiveVoice } from './no-passive-voice.js'
 import { noStackedAdjectives } from './no-stacked-adjectives.js'
 import { noWeakModals } from './no-weak-modals.js'
 
+export { noExpletiveOpeners } from './no-expletive-openers.js'
 export { noFilterWords } from './no-filter-words.js'
 export { noNominalizedPhrases } from './no-nominalized-phrases.js'
 export { noPassiveVoice } from './no-passive-voice.js'
 export { noStackedAdjectives } from './no-stacked-adjectives.js'
 export { noWeakModals } from './no-weak-modals.js'
+export type { NoExpletiveOpenersOptions } from './no-expletive-openers.js'
 export type { NoFilterWordsOptions } from './no-filter-words.js'
 export type { NoNominalizedPhrasesOptions } from './no-nominalized-phrases.js'
 export type { NoPassiveVoiceOptions } from './no-passive-voice.js'
@@ -18,6 +21,7 @@ export type { NoWeakModalsOptions } from './no-weak-modals.js'
 
 /** All NLP rules keyed by their rule ID. */
 export const ruleRegistry: Map<string, Rule> = new Map([
+  ['no-expletive-openers', noExpletiveOpeners as Rule],
   ['no-filter-words', noFilterWords as Rule],
   ['no-nominalized-phrases', noNominalizedPhrases as Rule],
   ['no-passive-voice', noPassiveVoice as Rule],

--- a/packages/rules-nlp/src/no-expletive-openers.ts
+++ b/packages/rules-nlp/src/no-expletive-openers.ts
@@ -1,0 +1,55 @@
+import type { Diagnostic, Rule, RuleInput } from '@faircopy/core'
+import { createDoc, getMatchOccurrences, getOccurrenceRange } from './utils.js'
+
+export interface NoExpletiveOpenersOptions {
+  phrases?: string[]
+}
+
+const DEFAULT_PHRASES = [
+  'there is',
+  'there are',
+  'there was',
+  'there were',
+  'there will be',
+  'it is',
+  'it was',
+]
+
+export const noExpletiveOpeners: Rule<NoExpletiveOpenersOptions> = {
+  id: 'no-expletive-openers',
+  description: 'Flag sentence openings that delay the real subject',
+  defaults: { phrases: DEFAULT_PHRASES },
+  help: 'Expletive openers like "there are" and "it is" make copy indirect. Start with the actor, product, or benefit so the sentence lands faster.',
+
+  check({ text, sourceMap, options }: RuleInput<NoExpletiveOpenersOptions>): Diagnostic[] {
+    const diagnostics: Diagnostic[] = []
+    const phrases = options.phrases?.length ? options.phrases : DEFAULT_PHRASES
+    const doc = createDoc(text)
+
+    for (const phrase of phrases) {
+      const matches = doc.match(phrase)
+      for (const occurrence of getMatchOccurrences(text, matches)) {
+        if (!startsSentence(text, occurrence.start)) continue
+
+        const range = getOccurrenceRange(sourceMap, occurrence)
+        if (!range) continue
+
+        diagnostics.push({
+          ruleId: 'no-expletive-openers',
+          severity: 'warn',
+          message: `start with the real subject instead of "${occurrence.text.toLowerCase()}"`,
+          range,
+          help: noExpletiveOpeners.help,
+        })
+      }
+    }
+
+    return diagnostics
+  },
+}
+
+function startsSentence(text: string, start: number): boolean {
+  let index = start - 1
+  while (index >= 0 && /\s/.test(text[index]!)) index--
+  return index < 0 || /[.!?]/.test(text[index]!)
+}

--- a/packages/rules-nlp/test/rules.test.mjs
+++ b/packages/rules-nlp/test/rules.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import {
+  noExpletiveOpeners,
   noNominalizedPhrases,
   noStackedAdjectives,
   noWeakModals,
@@ -59,7 +60,25 @@ test('no-nominalized-phrases allows configured concrete nouns', () => {
   assert.equal(diagnostics.length, 0)
 })
 
+test('no-expletive-openers flags there and it sentence openers', () => {
+  const text = 'There are faster ways to ship. It is easier with Faircopy.'
+  const diagnostics = run(noExpletiveOpeners, text)
+
+  assert.equal(diagnostics.length, 2)
+  assert.equal(diagnostics[0].ruleId, 'no-expletive-openers')
+  assert.deepEqual(diagnostics[0].range, { start: 0, end: 9 })
+  assert.deepEqual(diagnostics[1].range, { start: 31, end: 36 })
+})
+
+test('no-expletive-openers ignores matching phrases mid-sentence', () => {
+  const text = 'We know there are faster ways to ship.'
+  const diagnostics = run(noExpletiveOpeners, text)
+
+  assert.equal(diagnostics.length, 0)
+})
+
 test('rule registry exposes all nlp rules', () => {
+  assert.ok(ruleRegistry.has('no-expletive-openers'))
   assert.ok(ruleRegistry.has('no-filter-words'))
   assert.ok(ruleRegistry.has('no-passive-voice'))
   assert.ok(ruleRegistry.has('no-weak-modals'))


### PR DESCRIPTION
## Summary

- Add `no-expletive-openers` to `@faircopy/rules-nlp` to flag sentence-opening `There are`, `There is`, `It is`, and related constructions.
- Export and register the rule so it is available by bare ID and package-qualified ID.
- Document the rule in the root README and rules-nlp README, with focused tests for sentence-start matching and mid-sentence suppression.

## Validation

- `corepack pnpm --filter @faircopy/core build`
- `corepack pnpm --filter @faircopy/rules-nlp build`
- `corepack pnpm --filter @faircopy/rules-nlp typecheck`
- `node --test packages/rules-nlp/test/*.test.mjs`

## Notes

- Used an isolated checkout at `/workspace/group/repos/faircopy-ocpeyton` because `/workspace/group/repos/faircopy` had concurrent uncommitted work on `dex/nlp-high-signal-rules`.
