### PR TITLE
feat(rules-nlp): add pronoun and buzzword rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ export default defineConfig({
     'no-weak-modals': 'warn',
     'no-stacked-adjectives': 'warn',
     'no-nominalized-phrases': 'warn',
+    'no-pronoun-led-claims': 'warn',
+    'no-buzzword-stacks': 'warn',
   },
 })
 ```
@@ -96,6 +98,8 @@ Use a package-qualified ID if two loaded rulesets expose the same bare rule name
 | `@faircopy/rules-nlp/no-weak-modals` | Flag hedged modal claims like `can help` and `might improve` |
 | `@faircopy/rules-nlp/no-stacked-adjectives` | Flag noun phrases with multiple adjectives before the noun |
 | `@faircopy/rules-nlp/no-nominalized-phrases` | Flag nominalized `X of Y` phrases like `optimization of onboarding` |
+| `@faircopy/rules-nlp/no-pronoun-led-claims` | Flag vague sentence openers like `This helps` and `It enables` |
+| `@faircopy/rules-nlp/no-buzzword-stacks` | Flag sentences overloaded with abstract benefit nouns |
 
 ## Packages
 

--- a/packages/rules-nlp/README.md
+++ b/packages/rules-nlp/README.md
@@ -19,6 +19,8 @@ rules: {
   'no-weak-modals': 'warn',
   'no-stacked-adjectives': 'warn',
   'no-nominalized-phrases': 'warn',
+  'no-pronoun-led-claims': 'warn',
+  'no-buzzword-stacks': 'warn',
 }
 ```
 
@@ -36,3 +38,5 @@ Package-qualified IDs like `@faircopy/rules-nlp/no-passive-voice` still work and
 | `no-weak-modals` | Flag hedged modal claims like `can help` and `might improve` |
 | `no-stacked-adjectives` | Flag noun phrases with multiple adjectives before the noun |
 | `no-nominalized-phrases` | Flag nominalized `X of Y` phrases like `optimization of onboarding` |
+| `no-pronoun-led-claims` | Flag vague sentence openers like `This helps` and `It enables` |
+| `no-buzzword-stacks` | Flag sentences overloaded with abstract benefit nouns |

--- a/packages/rules-nlp/src/index.ts
+++ b/packages/rules-nlp/src/index.ts
@@ -1,37 +1,45 @@
 import type { Rule } from '@faircopy/core'
+import { noBuzzwordStacks } from './no-buzzword-stacks.js'
 import { noExpletiveOpeners } from './no-expletive-openers.js'
 import { noFilterWords } from './no-filter-words.js'
 import { noEmptyTransformationClaims } from './no-empty-transformation-claims.js'
 import { noNominalizedPhrases } from './no-nominalized-phrases.js'
 import { noPassiveVoice } from './no-passive-voice.js'
+import { noPronounLedClaims } from './no-pronoun-led-claims.js'
 import { noRedundantPairs } from './no-redundant-pairs.js'
 import { noStackedAdjectives } from './no-stacked-adjectives.js'
 import { noWeakModals } from './no-weak-modals.js'
 
+export { noBuzzwordStacks } from './no-buzzword-stacks.js'
 export { noExpletiveOpeners } from './no-expletive-openers.js'
 export { noFilterWords } from './no-filter-words.js'
 export { noEmptyTransformationClaims } from './no-empty-transformation-claims.js'
 export { noNominalizedPhrases } from './no-nominalized-phrases.js'
 export { noPassiveVoice } from './no-passive-voice.js'
+export { noPronounLedClaims } from './no-pronoun-led-claims.js'
 export { noRedundantPairs } from './no-redundant-pairs.js'
 export { noStackedAdjectives } from './no-stacked-adjectives.js'
 export { noWeakModals } from './no-weak-modals.js'
+export type { NoBuzzwordStacksOptions } from './no-buzzword-stacks.js'
 export type { NoExpletiveOpenersOptions } from './no-expletive-openers.js'
 export type { NoFilterWordsOptions } from './no-filter-words.js'
 export type { NoEmptyTransformationClaimsOptions } from './no-empty-transformation-claims.js'
 export type { NoNominalizedPhrasesOptions } from './no-nominalized-phrases.js'
 export type { NoPassiveVoiceOptions } from './no-passive-voice.js'
+export type { NoPronounLedClaimsOptions } from './no-pronoun-led-claims.js'
 export type { NoRedundantPairsOptions } from './no-redundant-pairs.js'
 export type { NoStackedAdjectivesOptions } from './no-stacked-adjectives.js'
 export type { NoWeakModalsOptions } from './no-weak-modals.js'
 
 /** All NLP rules keyed by their rule ID. */
 export const ruleRegistry: Map<string, Rule> = new Map([
+  ['no-buzzword-stacks', noBuzzwordStacks as Rule],
   ['no-empty-transformation-claims', noEmptyTransformationClaims as Rule],
   ['no-expletive-openers', noExpletiveOpeners as Rule],
   ['no-filter-words', noFilterWords as Rule],
   ['no-nominalized-phrases', noNominalizedPhrases as Rule],
   ['no-passive-voice', noPassiveVoice as Rule],
+  ['no-pronoun-led-claims', noPronounLedClaims as Rule],
   ['no-redundant-pairs', noRedundantPairs as Rule],
   ['no-stacked-adjectives', noStackedAdjectives as Rule],
   ['no-weak-modals', noWeakModals as Rule],

--- a/packages/rules-nlp/src/no-buzzword-stacks.ts
+++ b/packages/rules-nlp/src/no-buzzword-stacks.ts
@@ -1,0 +1,105 @@
+import type { Diagnostic, Rule, RuleInput } from '@faircopy/core'
+
+export interface NoBuzzwordStacksOptions {
+  terms?: string[]
+  maxTermsPerSentence?: number
+}
+
+const DEFAULT_TERMS = [
+  'alignment',
+  'automation',
+  'collaboration',
+  'efficiency',
+  'engagement',
+  'experience',
+  'growth',
+  'impact',
+  'innovation',
+  'intelligence',
+  'optimization',
+  'platform',
+  'productivity',
+  'solution',
+  'strategy',
+  'transformation',
+  'value',
+  'velocity',
+  'workflow',
+]
+
+export const noBuzzwordStacks: Rule<NoBuzzwordStacksOptions> = {
+  id: 'no-buzzword-stacks',
+  description: 'Flag sentences overloaded with abstract benefit nouns',
+  defaults: { terms: DEFAULT_TERMS, maxTermsPerSentence: 2 },
+  help: 'Buzzword-heavy sentences make copy sound interchangeable. Replace abstract benefit nouns with the specific product behavior, customer outcome, or proof point.',
+
+  check({ text, sourceMap, options }: RuleInput<NoBuzzwordStacksOptions>): Diagnostic[] {
+    const diagnostics: Diagnostic[] = []
+    const terms = options.terms?.length ? options.terms : DEFAULT_TERMS
+    const maxTermsPerSentence = options.maxTermsPerSentence ?? 2
+    if (maxTermsPerSentence < 1) return diagnostics
+
+    for (const sentence of getSentenceRanges(text)) {
+      const hits = getTermHits(sentence.text, terms)
+      if (hits.length <= maxTermsPerSentence) continue
+
+      const startOffset = sentence.start + hits[0]!.start
+      const endOffset = sentence.start + hits[hits.length - 1]!.end
+      const start = sourceMap[startOffset]
+      const end = sourceMap[endOffset - 1]
+      if (start === undefined || end === undefined) continue
+
+      const words = hits.map(hit => hit.text.toLowerCase()).join(', ')
+      diagnostics.push({
+        ruleId: 'no-buzzword-stacks',
+        severity: 'warn',
+        message: `replace buzzword stack: ${words}`,
+        range: { start, end: end + 1 },
+        help: noBuzzwordStacks.help,
+      })
+    }
+
+    return diagnostics
+  },
+}
+
+interface SentenceRange {
+  text: string
+  start: number
+}
+
+interface TermHit {
+  text: string
+  start: number
+  end: number
+}
+
+function getSentenceRanges(text: string): SentenceRange[] {
+  const ranges: SentenceRange[] = []
+  const re = /[^.!?]+[.!?]?/g
+  let match: RegExpExecArray | null
+  while ((match = re.exec(text)) !== null) {
+    const leadingWhitespaceLength = match[0].match(/^\s*/)?.[0].length ?? 0
+    const sentence = match[0].trim()
+    if (!sentence) continue
+    ranges.push({ text: sentence, start: match.index + leadingWhitespaceLength })
+  }
+  return ranges
+}
+
+function getTermHits(text: string, terms: string[]): TermHit[] {
+  const termPattern = terms.map(escapeRegex).join('|')
+  if (!termPattern) return []
+
+  const hits: TermHit[] = []
+  const re = new RegExp(`\\b(${termPattern})\\b`, 'gi')
+  let match: RegExpExecArray | null
+  while ((match = re.exec(text)) !== null) {
+    hits.push({ text: match[0], start: match.index, end: match.index + match[0].length })
+  }
+  return hits
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}

--- a/packages/rules-nlp/src/no-pronoun-led-claims.ts
+++ b/packages/rules-nlp/src/no-pronoun-led-claims.ts
@@ -1,0 +1,61 @@
+import type { Diagnostic, Rule, RuleInput } from '@faircopy/core'
+
+export interface NoPronounLedClaimsOptions {
+  pronouns?: string[]
+  verbs?: string[]
+}
+
+const DEFAULT_PRONOUNS = ['it', 'this', 'that', 'these', 'those']
+const DEFAULT_VERBS = [
+  'brings',
+  'delivers',
+  'enables',
+  'gives',
+  'helps',
+  'keeps',
+  'lets',
+  'makes',
+  'turns',
+  'unlocks',
+]
+
+export const noPronounLedClaims: Rule<NoPronounLedClaimsOptions> = {
+  id: 'no-pronoun-led-claims',
+  description: 'Flag vague claims that start with it, this, that, these, or those',
+  defaults: { pronouns: DEFAULT_PRONOUNS, verbs: DEFAULT_VERBS },
+  help: 'Pronoun-led claims make the reader infer the subject. Name the feature, product, or user action that creates the outcome.',
+
+  check({ text, sourceMap, options }: RuleInput<NoPronounLedClaimsOptions>): Diagnostic[] {
+    const diagnostics: Diagnostic[] = []
+    const pronouns = options.pronouns?.length ? options.pronouns : DEFAULT_PRONOUNS
+    const verbs = options.verbs?.length ? options.verbs : DEFAULT_VERBS
+    if (!pronouns.length || !verbs.length) return diagnostics
+
+    const re = new RegExp(
+      `(?:^|[.!?]\\s+)(${pronouns.map(escapeRegex).join('|')})\\s+(${verbs.map(escapeRegex).join('|')})\\b`,
+      'gi'
+    )
+    let match: RegExpExecArray | null
+    while ((match = re.exec(text)) !== null) {
+      const phrase = `${match[1]} ${match[2]}`
+      const phraseStart = match.index + match[0].indexOf(phrase)
+      const start = sourceMap[phraseStart]
+      const end = sourceMap[phraseStart + phrase.length - 1]
+      if (start === undefined || end === undefined) continue
+
+      diagnostics.push({
+        ruleId: 'no-pronoun-led-claims',
+        severity: 'warn',
+        message: `name the subject instead of "${phrase.toLowerCase()}"`,
+        range: { start, end: end + 1 },
+        help: noPronounLedClaims.help,
+      })
+    }
+
+    return diagnostics
+  },
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}

--- a/packages/rules-nlp/test/rules.test.mjs
+++ b/packages/rules-nlp/test/rules.test.mjs
@@ -1,9 +1,11 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import {
+  noBuzzwordStacks,
   noEmptyTransformationClaims,
   noExpletiveOpeners,
   noNominalizedPhrases,
+  noPronounLedClaims,
   noRedundantPairs,
   noStackedAdjectives,
   noWeakModals,
@@ -146,11 +148,50 @@ test('no-expletive-openers ignores matching phrases mid-sentence', () => {
   assert.equal(diagnostics.length, 0)
 })
 
+test('no-pronoun-led-claims flags vague sentence openers', () => {
+  const text = 'This helps teams move faster. The assistant helps teams decide.'
+  const diagnostics = run(noPronounLedClaims, text)
+
+  assert.equal(diagnostics.length, 1)
+  assert.equal(diagnostics[0].ruleId, 'no-pronoun-led-claims')
+  assert.deepEqual(diagnostics[0].range, { start: 0, end: 10 })
+})
+
+test('no-pronoun-led-claims allows configured verbs', () => {
+  const text = 'This helps teams move faster.'
+  const diagnostics = run(noPronounLedClaims, text, {
+    verbs: ['delivers'],
+  })
+
+  assert.equal(diagnostics.length, 0)
+})
+
+test('no-buzzword-stacks flags abstract benefit pileups', () => {
+  const text = 'Our platform drives productivity, collaboration, and transformation.'
+  const diagnostics = run(noBuzzwordStacks, text)
+
+  assert.equal(diagnostics.length, 1)
+  assert.equal(diagnostics[0].ruleId, 'no-buzzword-stacks')
+  assert.deepEqual(diagnostics[0].range, { start: 4, end: 67 })
+  assert.match(diagnostics[0].message, /platform, productivity, collaboration, transformation/)
+})
+
+test('no-buzzword-stacks respects the configured threshold', () => {
+  const text = 'Our platform drives productivity, collaboration, and transformation.'
+  const diagnostics = run(noBuzzwordStacks, text, {
+    maxTermsPerSentence: 4,
+  })
+
+  assert.equal(diagnostics.length, 0)
+})
+
 test('rule registry exposes all nlp rules', () => {
+  assert.ok(ruleRegistry.has('no-buzzword-stacks'))
   assert.ok(ruleRegistry.has('no-empty-transformation-claims'))
   assert.ok(ruleRegistry.has('no-expletive-openers'))
   assert.ok(ruleRegistry.has('no-filter-words'))
   assert.ok(ruleRegistry.has('no-passive-voice'))
+  assert.ok(ruleRegistry.has('no-pronoun-led-claims'))
   assert.ok(ruleRegistry.has('no-redundant-pairs'))
   assert.ok(ruleRegistry.has('no-weak-modals'))
   assert.ok(ruleRegistry.has('no-stacked-adjectives'))


### PR DESCRIPTION
## Summary
- adds `no-pronoun-led-claims` to catch vague sentence openers like `This helps`
- adds `no-buzzword-stacks` to catch abstract benefit pileups in one sentence
- exports/registers both rules and documents their bare IDs for `@faircopy/rules-nlp`

## Tests
- `corepack pnpm --filter @faircopy/rules-nlp typecheck`
- `PATH="$tmpbin:$PATH" corepack pnpm --filter @faircopy/rules-nlp test`
- `PATH="$tmpbin:$PATH" corepack pnpm typecheck`
- `PATH="$tmpbin:$PATH" corepack pnpm test`
- `PATH="$tmpbin:$PATH" corepack pnpm build`
- `git diff --check`

## Notes
- This branch is based on `origin/main` and does not include the `no-empty-transformation-claims` work from #9.
- `pnpm` is available through Corepack here, but no global shim exists in `/usr/bin`, so nested package scripts needed a temporary PATH shim outside the repo.
