### PR TITLE
feat(rules-nlp): flag redundant fixed phrases

### DIFF
--- a/packages/rules-nlp/README.md
+++ b/packages/rules-nlp/README.md
@@ -14,6 +14,7 @@ rules: {
   'no-filter-words': 'warn',
   'no-empty-transformation-claims': 'warn',
   'no-passive-voice': 'warn',
+  'no-redundant-pairs': 'warn',
   'no-weak-modals': 'warn',
   'no-stacked-adjectives': 'warn',
   'no-nominalized-phrases': 'warn',
@@ -29,6 +30,7 @@ Package-qualified IDs like `@faircopy/rules-nlp/no-passive-voice` still work and
 | `no-empty-transformation-claims` | Flag broad transformation cliches like `transform the way teams work` |
 | `no-filter-words` | Ban filter phrases like `I think` and `it seems` |
 | `no-passive-voice` | Flag likely passive-voice constructions |
+| `no-redundant-pairs` | Flag redundant fixed phrases like `first and foremost` |
 | `no-weak-modals` | Flag hedged modal claims like `can help` and `might improve` |
 | `no-stacked-adjectives` | Flag noun phrases with multiple adjectives before the noun |
 | `no-nominalized-phrases` | Flag nominalized `X of Y` phrases like `optimization of onboarding` |

--- a/packages/rules-nlp/src/index.ts
+++ b/packages/rules-nlp/src/index.ts
@@ -3,6 +3,7 @@ import { noFilterWords } from './no-filter-words.js'
 import { noEmptyTransformationClaims } from './no-empty-transformation-claims.js'
 import { noNominalizedPhrases } from './no-nominalized-phrases.js'
 import { noPassiveVoice } from './no-passive-voice.js'
+import { noRedundantPairs } from './no-redundant-pairs.js'
 import { noStackedAdjectives } from './no-stacked-adjectives.js'
 import { noWeakModals } from './no-weak-modals.js'
 
@@ -10,12 +11,14 @@ export { noFilterWords } from './no-filter-words.js'
 export { noEmptyTransformationClaims } from './no-empty-transformation-claims.js'
 export { noNominalizedPhrases } from './no-nominalized-phrases.js'
 export { noPassiveVoice } from './no-passive-voice.js'
+export { noRedundantPairs } from './no-redundant-pairs.js'
 export { noStackedAdjectives } from './no-stacked-adjectives.js'
 export { noWeakModals } from './no-weak-modals.js'
 export type { NoFilterWordsOptions } from './no-filter-words.js'
 export type { NoEmptyTransformationClaimsOptions } from './no-empty-transformation-claims.js'
 export type { NoNominalizedPhrasesOptions } from './no-nominalized-phrases.js'
 export type { NoPassiveVoiceOptions } from './no-passive-voice.js'
+export type { NoRedundantPairsOptions } from './no-redundant-pairs.js'
 export type { NoStackedAdjectivesOptions } from './no-stacked-adjectives.js'
 export type { NoWeakModalsOptions } from './no-weak-modals.js'
 
@@ -25,6 +28,7 @@ export const ruleRegistry: Map<string, Rule> = new Map([
   ['no-filter-words', noFilterWords as Rule],
   ['no-nominalized-phrases', noNominalizedPhrases as Rule],
   ['no-passive-voice', noPassiveVoice as Rule],
+  ['no-redundant-pairs', noRedundantPairs as Rule],
   ['no-stacked-adjectives', noStackedAdjectives as Rule],
   ['no-weak-modals', noWeakModals as Rule],
 ])

--- a/packages/rules-nlp/src/no-redundant-pairs.ts
+++ b/packages/rules-nlp/src/no-redundant-pairs.ts
@@ -1,0 +1,55 @@
+import type { Diagnostic, Rule, RuleInput } from '@faircopy/core'
+
+export interface NoRedundantPairsOptions {
+  phrases?: string[]
+}
+
+const DEFAULT_PHRASES = [
+  'first and foremost',
+  'each and every',
+  'various different',
+  'end result',
+  'final outcome',
+  'past history',
+  'future plans',
+  'unexpected surprise',
+  'advance planning',
+]
+
+export const noRedundantPairs: Rule<NoRedundantPairsOptions> = {
+  id: 'no-redundant-pairs',
+  description: 'Flag redundant word pairs and padded fixed phrases',
+  defaults: { phrases: DEFAULT_PHRASES },
+  help: 'Redundant pairs repeat the same idea twice. Keep the stronger word or replace the phrase with a more specific claim.',
+
+  check({ text, sourceMap, options }: RuleInput<NoRedundantPairsOptions>): Diagnostic[] {
+    const diagnostics: Diagnostic[] = []
+    const phrases = options.phrases?.length ? options.phrases : DEFAULT_PHRASES
+
+    for (const phrase of phrases) {
+      const re = new RegExp(`\\b${escapeRegExp(phrase).replace(/\\s+/g, '\\s+')}\\b`, 'gi')
+      let match: RegExpExecArray | null
+
+      while ((match = re.exec(text)) !== null) {
+        const matchedPhrase = match[0]
+        const start = sourceMap[match.index]
+        const end = sourceMap[match.index + matchedPhrase.length - 1]
+        if (start === undefined || end === undefined) continue
+
+        diagnostics.push({
+          ruleId: 'no-redundant-pairs',
+          severity: 'warn',
+          message: `tighten redundant phrase "${matchedPhrase}"`,
+          range: { start, end: end + 1 },
+          help: noRedundantPairs.help,
+        })
+      }
+    }
+
+    return diagnostics
+  },
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}

--- a/packages/rules-nlp/test/rules.test.mjs
+++ b/packages/rules-nlp/test/rules.test.mjs
@@ -3,6 +3,7 @@ import test from 'node:test'
 import {
   noEmptyTransformationClaims,
   noNominalizedPhrases,
+  noRedundantPairs,
   noStackedAdjectives,
   noWeakModals,
   ruleRegistry,
@@ -97,10 +98,34 @@ test('no-nominalized-phrases allows configured concrete nouns', () => {
   assert.equal(diagnostics.length, 0)
 })
 
+test('no-redundant-pairs flags default redundant phrases', () => {
+  const text = 'First and foremost, remove the end result from your future plans.'
+  const diagnostics = run(noRedundantPairs, text)
+
+  assert.equal(diagnostics.length, 3)
+  assert.equal(diagnostics[0].ruleId, 'no-redundant-pairs')
+  assert.deepEqual(diagnostics.map(diagnostic => diagnostic.range), [
+    { start: 0, end: 18 },
+    { start: 31, end: 41 },
+    { start: 52, end: 64 },
+  ])
+})
+
+test('no-redundant-pairs supports custom phrase lists', () => {
+  const text = 'The real truth is clear, but the end result is noisy.'
+  const diagnostics = run(noRedundantPairs, text, {
+    phrases: ['real truth'],
+  })
+
+  assert.equal(diagnostics.length, 1)
+  assert.match(diagnostics[0].message, /real truth/)
+})
+
 test('rule registry exposes all nlp rules', () => {
   assert.ok(ruleRegistry.has('no-empty-transformation-claims'))
   assert.ok(ruleRegistry.has('no-filter-words'))
   assert.ok(ruleRegistry.has('no-passive-voice'))
+  assert.ok(ruleRegistry.has('no-redundant-pairs'))
   assert.ok(ruleRegistry.has('no-weak-modals'))
   assert.ok(ruleRegistry.has('no-stacked-adjectives'))
   assert.ok(ruleRegistry.has('no-nominalized-phrases'))


### PR DESCRIPTION
## Summary
- Add `no-redundant-pairs` to `@faircopy/rules-nlp` for padded fixed phrases like `first and foremost`, `each and every`, and `future plans`.
- Expose the rule through the package registry/exports and document it in the README.
- Add focused tests for default phrase matching, custom `phrases`, and registry exposure.

## Validation
- `CI=true bunx pnpm@9 build`
- `CI=true bunx pnpm@9 typecheck`
- `CI=true bunx pnpm@9 test`
