### PR TITLE
feat(rules-nlp): flag hedge words

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ export default defineConfig({
   rules: {
     'no-expletive-openers': 'warn',
     'no-filter-words': 'warn',
+    'no-hedge-words': 'warn',
     'no-passive-voice': 'warn',
     'no-weak-modals': 'warn',
     'no-stacked-adjectives': 'warn',
@@ -94,6 +95,7 @@ Use a package-qualified ID if two loaded rulesets expose the same bare rule name
 |---|---|
 | `@faircopy/rules-nlp/no-expletive-openers` | Flag sentence openings like `There are` |
 | `@faircopy/rules-nlp/no-filter-words` | Ban filter phrases like `I think` and `it seems` |
+| `@faircopy/rules-nlp/no-hedge-words` | Flag hedge words like `kind of` and `somewhat` |
 | `@faircopy/rules-nlp/no-passive-voice` | Flag likely passive-voice constructions |
 | `@faircopy/rules-nlp/no-weak-modals` | Flag hedged modal claims like `can help` and `might improve` |
 | `@faircopy/rules-nlp/no-stacked-adjectives` | Flag noun phrases with multiple adjectives before the noun |

--- a/packages/rules-nlp/README.md
+++ b/packages/rules-nlp/README.md
@@ -13,6 +13,7 @@ rulesets: ['@faircopy/rules-nlp'],
 rules: {
   'no-expletive-openers': 'warn',
   'no-filter-words': 'warn',
+  'no-hedge-words': 'warn',
   'no-empty-transformation-claims': 'warn',
   'no-passive-voice': 'warn',
   'no-redundant-pairs': 'warn',
@@ -33,6 +34,7 @@ Package-qualified IDs like `@faircopy/rules-nlp/no-passive-voice` still work and
 | `no-empty-transformation-claims` | Flag broad transformation cliches like `transform the way teams work` |
 | `no-expletive-openers` | Flag sentence openings like `There are` |
 | `no-filter-words` | Ban filter phrases like `I think` and `it seems` |
+| `no-hedge-words` | Flag hedge words like `kind of` and `somewhat` |
 | `no-passive-voice` | Flag likely passive-voice constructions |
 | `no-redundant-pairs` | Flag redundant fixed phrases like `first and foremost` |
 | `no-weak-modals` | Flag hedged modal claims like `can help` and `might improve` |

--- a/packages/rules-nlp/src/index.ts
+++ b/packages/rules-nlp/src/index.ts
@@ -3,6 +3,7 @@ import { noBuzzwordStacks } from './no-buzzword-stacks.js'
 import { noExpletiveOpeners } from './no-expletive-openers.js'
 import { noFilterWords } from './no-filter-words.js'
 import { noEmptyTransformationClaims } from './no-empty-transformation-claims.js'
+import { noHedgeWords } from './no-hedge-words.js'
 import { noNominalizedPhrases } from './no-nominalized-phrases.js'
 import { noPassiveVoice } from './no-passive-voice.js'
 import { noPronounLedClaims } from './no-pronoun-led-claims.js'
@@ -14,6 +15,7 @@ export { noBuzzwordStacks } from './no-buzzword-stacks.js'
 export { noExpletiveOpeners } from './no-expletive-openers.js'
 export { noFilterWords } from './no-filter-words.js'
 export { noEmptyTransformationClaims } from './no-empty-transformation-claims.js'
+export { noHedgeWords } from './no-hedge-words.js'
 export { noNominalizedPhrases } from './no-nominalized-phrases.js'
 export { noPassiveVoice } from './no-passive-voice.js'
 export { noPronounLedClaims } from './no-pronoun-led-claims.js'
@@ -24,6 +26,7 @@ export type { NoBuzzwordStacksOptions } from './no-buzzword-stacks.js'
 export type { NoExpletiveOpenersOptions } from './no-expletive-openers.js'
 export type { NoFilterWordsOptions } from './no-filter-words.js'
 export type { NoEmptyTransformationClaimsOptions } from './no-empty-transformation-claims.js'
+export type { NoHedgeWordsOptions } from './no-hedge-words.js'
 export type { NoNominalizedPhrasesOptions } from './no-nominalized-phrases.js'
 export type { NoPassiveVoiceOptions } from './no-passive-voice.js'
 export type { NoPronounLedClaimsOptions } from './no-pronoun-led-claims.js'
@@ -37,6 +40,7 @@ export const ruleRegistry: Map<string, Rule> = new Map([
   ['no-empty-transformation-claims', noEmptyTransformationClaims as Rule],
   ['no-expletive-openers', noExpletiveOpeners as Rule],
   ['no-filter-words', noFilterWords as Rule],
+  ['no-hedge-words', noHedgeWords as Rule],
   ['no-nominalized-phrases', noNominalizedPhrases as Rule],
   ['no-passive-voice', noPassiveVoice as Rule],
   ['no-pronoun-led-claims', noPronounLedClaims as Rule],

--- a/packages/rules-nlp/src/no-hedge-words.ts
+++ b/packages/rules-nlp/src/no-hedge-words.ts
@@ -1,0 +1,56 @@
+import type { Diagnostic, Rule, RuleInput } from '@faircopy/core'
+
+export interface NoHedgeWordsOptions {
+  hedges?: string[]
+}
+
+const DEFAULT_HEDGES = [
+  'kind of',
+  'sort of',
+  'somewhat',
+  'fairly',
+  'pretty',
+  'rather',
+  'quite',
+  'arguably',
+  'relatively',
+  'more or less',
+]
+
+export const noHedgeWords: Rule<NoHedgeWordsOptions> = {
+  id: 'no-hedge-words',
+  description: 'Flag hedge words that soften claims',
+  defaults: { hedges: DEFAULT_HEDGES },
+  help: 'Hedge words make claims sound uncertain. Remove the hedge or replace the sentence with a specific proof point. Words like "pretty" and "quite" can be intentional adjectives in some contexts; override hedges when that trade-off is too noisy for your copy.',
+
+  check({ text, sourceMap, options }: RuleInput<NoHedgeWordsOptions>): Diagnostic[] {
+    const diagnostics: Diagnostic[] = []
+    const hedges = options.hedges?.length ? options.hedges : DEFAULT_HEDGES
+
+    for (const hedge of hedges) {
+      const re = new RegExp(`\\b${escapeRegExp(hedge).replace(/\\s+/g, '\\s+')}\\b`, 'gi')
+      let match: RegExpExecArray | null
+
+      while ((match = re.exec(text)) !== null) {
+        const phrase = match[0]
+        const start = sourceMap[match.index]
+        const end = sourceMap[match.index + phrase.length - 1]
+        if (start === undefined || end === undefined) continue
+
+        diagnostics.push({
+          ruleId: 'no-hedge-words',
+          severity: 'warn',
+          message: `remove hedge "${phrase.toLowerCase()}"`,
+          range: { start, end: end + 1 },
+          help: noHedgeWords.help,
+        })
+      }
+    }
+
+    return diagnostics
+  },
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}

--- a/packages/rules-nlp/test/rules.test.mjs
+++ b/packages/rules-nlp/test/rules.test.mjs
@@ -4,6 +4,7 @@ import {
   noBuzzwordStacks,
   noEmptyTransformationClaims,
   noExpletiveOpeners,
+  noHedgeWords,
   noNominalizedPhrases,
   noPronounLedClaims,
   noRedundantPairs,
@@ -148,6 +149,29 @@ test('no-expletive-openers ignores matching phrases mid-sentence', () => {
   assert.equal(diagnostics.length, 0)
 })
 
+test('no-hedge-words flags default hedge words', () => {
+  const text = 'This is kind of fast, somewhat useful, and more or less ready.'
+  const diagnostics = run(noHedgeWords, text)
+
+  assert.equal(diagnostics.length, 3)
+  assert.equal(diagnostics[0].ruleId, 'no-hedge-words')
+  assert.deepEqual(diagnostics.map(diagnostic => diagnostic.range), [
+    { start: 8, end: 15 },
+    { start: 22, end: 30 },
+    { start: 43, end: 55 },
+  ])
+})
+
+test('no-hedge-words supports custom hedge lists', () => {
+  const text = 'The workflow is pretty fast and arguably safer.'
+  const diagnostics = run(noHedgeWords, text, {
+    hedges: ['arguably'],
+  })
+
+  assert.equal(diagnostics.length, 1)
+  assert.match(diagnostics[0].message, /arguably/)
+})
+
 test('no-pronoun-led-claims flags vague sentence openers', () => {
   const text = 'This helps teams move faster. The assistant helps teams decide.'
   const diagnostics = run(noPronounLedClaims, text)
@@ -190,6 +214,7 @@ test('rule registry exposes all nlp rules', () => {
   assert.ok(ruleRegistry.has('no-empty-transformation-claims'))
   assert.ok(ruleRegistry.has('no-expletive-openers'))
   assert.ok(ruleRegistry.has('no-filter-words'))
+  assert.ok(ruleRegistry.has('no-hedge-words'))
   assert.ok(ruleRegistry.has('no-passive-voice'))
   assert.ok(ruleRegistry.has('no-pronoun-led-claims'))
   assert.ok(ruleRegistry.has('no-redundant-pairs'))


### PR DESCRIPTION
## Summary
- Add `no-hedge-words` to `@faircopy/rules-nlp` for softened claims like `kind of`, `somewhat`, and `more or less`.
- Wire the rule through exports, `ruleRegistry`, the package README, and the root README.
- Add focused tests for default hedge matching, custom `hedges`, and registry exposure.

## Risk Note
`pretty` and `quite` can be legitimate adjectival uses in some copy. The rule documents that trade-off in its help text and supports overriding `hedges` to opt out of noisy terms.

## Validation
- `CI=true bunx pnpm@9 build`
- `CI=true bunx pnpm@9 typecheck`
- `CI=true bunx pnpm@9 test`
