### PR TITLE
feat(rules-nlp): add no-vague-quantifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ export default defineConfig({
     'no-nominalized-phrases': 'warn',
     'no-pronoun-led-claims': 'warn',
     'no-buzzword-stacks': 'warn',
+    'no-vague-quantifiers': 'warn',
   },
 })
 ```
@@ -100,6 +101,7 @@ Use a package-qualified ID if two loaded rulesets expose the same bare rule name
 | `@faircopy/rules-nlp/no-nominalized-phrases` | Flag nominalized `X of Y` phrases like `optimization of onboarding` |
 | `@faircopy/rules-nlp/no-pronoun-led-claims` | Flag vague sentence openers like `This helps` and `It enables` |
 | `@faircopy/rules-nlp/no-buzzword-stacks` | Flag sentences overloaded with abstract benefit nouns |
+| `@faircopy/rules-nlp/no-vague-quantifiers` | Flag bare quantifiers without numeric anchors |
 
 ## Packages
 

--- a/packages/rules-nlp/README.md
+++ b/packages/rules-nlp/README.md
@@ -21,6 +21,7 @@ rules: {
   'no-nominalized-phrases': 'warn',
   'no-pronoun-led-claims': 'warn',
   'no-buzzword-stacks': 'warn',
+  'no-vague-quantifiers': 'warn',
 }
 ```
 
@@ -40,3 +41,4 @@ Package-qualified IDs like `@faircopy/rules-nlp/no-passive-voice` still work and
 | `no-nominalized-phrases` | Flag nominalized `X of Y` phrases like `optimization of onboarding` |
 | `no-pronoun-led-claims` | Flag vague sentence openers like `This helps` and `It enables` |
 | `no-buzzword-stacks` | Flag sentences overloaded with abstract benefit nouns |
+| `no-vague-quantifiers` | Flag bare quantifiers without numeric anchors |

--- a/packages/rules-nlp/src/index.ts
+++ b/packages/rules-nlp/src/index.ts
@@ -8,6 +8,7 @@ import { noPassiveVoice } from './no-passive-voice.js'
 import { noPronounLedClaims } from './no-pronoun-led-claims.js'
 import { noRedundantPairs } from './no-redundant-pairs.js'
 import { noStackedAdjectives } from './no-stacked-adjectives.js'
+import { noVagueQuantifiers } from './no-vague-quantifiers.js'
 import { noWeakModals } from './no-weak-modals.js'
 
 export { noBuzzwordStacks } from './no-buzzword-stacks.js'
@@ -19,6 +20,7 @@ export { noPassiveVoice } from './no-passive-voice.js'
 export { noPronounLedClaims } from './no-pronoun-led-claims.js'
 export { noRedundantPairs } from './no-redundant-pairs.js'
 export { noStackedAdjectives } from './no-stacked-adjectives.js'
+export { noVagueQuantifiers } from './no-vague-quantifiers.js'
 export { noWeakModals } from './no-weak-modals.js'
 export type { NoBuzzwordStacksOptions } from './no-buzzword-stacks.js'
 export type { NoExpletiveOpenersOptions } from './no-expletive-openers.js'
@@ -29,6 +31,7 @@ export type { NoPassiveVoiceOptions } from './no-passive-voice.js'
 export type { NoPronounLedClaimsOptions } from './no-pronoun-led-claims.js'
 export type { NoRedundantPairsOptions } from './no-redundant-pairs.js'
 export type { NoStackedAdjectivesOptions } from './no-stacked-adjectives.js'
+export type { NoVagueQuantifiersOptions } from './no-vague-quantifiers.js'
 export type { NoWeakModalsOptions } from './no-weak-modals.js'
 
 /** All NLP rules keyed by their rule ID. */
@@ -42,5 +45,6 @@ export const ruleRegistry: Map<string, Rule> = new Map([
   ['no-pronoun-led-claims', noPronounLedClaims as Rule],
   ['no-redundant-pairs', noRedundantPairs as Rule],
   ['no-stacked-adjectives', noStackedAdjectives as Rule],
+  ['no-vague-quantifiers', noVagueQuantifiers as Rule],
   ['no-weak-modals', noWeakModals as Rule],
 ])

--- a/packages/rules-nlp/src/no-vague-quantifiers.ts
+++ b/packages/rules-nlp/src/no-vague-quantifiers.ts
@@ -1,0 +1,63 @@
+import type { Diagnostic, Rule, RuleInput } from '@faircopy/core'
+
+export interface NoVagueQuantifiersOptions {
+  quantifiers?: string[]
+}
+
+const DEFAULT_QUANTIFIERS = [
+  'many',
+  'several',
+  'various',
+  'numerous',
+  'multiple',
+  'some',
+  'a number of',
+  'a variety of',
+  'a range of',
+  'a host of',
+  'countless',
+  'tons of',
+  'lots of',
+]
+
+export const noVagueQuantifiers: Rule<NoVagueQuantifiersOptions> = {
+  id: 'no-vague-quantifiers',
+  description: 'Flag bare quantifiers without numeric anchors',
+  defaults: { quantifiers: DEFAULT_QUANTIFIERS },
+  help:
+    'Vague quantifiers make claims hard to evaluate. Replace them with a number, range, or concrete scope when precision matters.',
+
+  check({ text, sourceMap, options }: RuleInput<NoVagueQuantifiersOptions>): Diagnostic[] {
+    const diagnostics: Diagnostic[] = []
+    const quantifiers = options.quantifiers?.length ? options.quantifiers : DEFAULT_QUANTIFIERS
+
+    for (const quantifier of quantifiers) {
+      const re = new RegExp(
+        `\\b${escapeRegExp(quantifier).replace(/\\s+/g, '\\s+')}\\b`,
+        'gi'
+      )
+      let match: RegExpExecArray | null
+
+      while ((match = re.exec(text)) !== null) {
+        const matchedQuantifier = match[0]
+        const start = sourceMap[match.index]
+        const end = sourceMap[match.index + matchedQuantifier.length - 1]
+        if (start === undefined || end === undefined) continue
+
+        diagnostics.push({
+          ruleId: 'no-vague-quantifiers',
+          severity: 'warn',
+          message: `replace vague quantifier "${matchedQuantifier}" with a number or concrete scope`,
+          range: { start, end: end + 1 },
+          help: noVagueQuantifiers.help,
+        })
+      }
+    }
+
+    return diagnostics
+  },
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}

--- a/packages/rules-nlp/test/rules.test.mjs
+++ b/packages/rules-nlp/test/rules.test.mjs
@@ -8,6 +8,7 @@ import {
   noPronounLedClaims,
   noRedundantPairs,
   noStackedAdjectives,
+  noVagueQuantifiers,
   noWeakModals,
   ruleRegistry,
 } from '../dist/index.js'
@@ -185,6 +186,37 @@ test('no-buzzword-stacks respects the configured threshold', () => {
   assert.equal(diagnostics.length, 0)
 })
 
+test('no-vague-quantifiers flags default bare quantifiers', () => {
+  const text = 'Many teams see several wins across a range of workflows.'
+  const diagnostics = run(noVagueQuantifiers, text)
+
+  assert.equal(diagnostics.length, 3)
+  assert.equal(diagnostics[0].ruleId, 'no-vague-quantifiers')
+  assert.deepEqual(diagnostics.map(diagnostic => diagnostic.range), [
+    { start: 0, end: 4 },
+    { start: 15, end: 22 },
+    { start: 35, end: 45 },
+  ])
+})
+
+test('no-vague-quantifiers supports custom phrases', () => {
+  const text = 'Heaps of users asked for a bunch of exports.'
+  const diagnostics = run(noVagueQuantifiers, text, {
+    quantifiers: ['a bunch of'],
+  })
+
+  assert.equal(diagnostics.length, 1)
+  assert.match(diagnostics[0].message, /a bunch of/)
+})
+
+test('no-vague-quantifiers flags matching phrases mid-sentence', () => {
+  const text = 'The report mentions lots of customers but includes no count.'
+  const diagnostics = run(noVagueQuantifiers, text)
+
+  assert.equal(diagnostics.length, 1)
+  assert.deepEqual(diagnostics[0].range, { start: 20, end: 27 })
+})
+
 test('rule registry exposes all nlp rules', () => {
   assert.ok(ruleRegistry.has('no-buzzword-stacks'))
   assert.ok(ruleRegistry.has('no-empty-transformation-claims'))
@@ -196,4 +228,5 @@ test('rule registry exposes all nlp rules', () => {
   assert.ok(ruleRegistry.has('no-weak-modals'))
   assert.ok(ruleRegistry.has('no-stacked-adjectives'))
   assert.ok(ruleRegistry.has('no-nominalized-phrases'))
+  assert.ok(ruleRegistry.has('no-vague-quantifiers'))
 })


### PR DESCRIPTION
## Summary

- Adds `no-vague-quantifiers` to `@faircopy/rules-nlp`.
- Flags default bare quantifiers including `many`, `several`, `a range of`, `tons of`, and `lots of`.
- Wires the rule through exports, `ruleRegistry`, root docs, package docs, and focused tests.

## Options

- `quantifiers?: string[]` overrides the default quantifier phrase list.

## Verification

- `bun run --filter @faircopy/rules-nlp typecheck`
- `bun run --filter @faircopy/rules-nlp test`
- `bun run --filter './packages/*' build`
- `bun run --filter './packages/*' typecheck`
- `bun run --filter './packages/*' test`

Note: root `bun run build/typecheck/test` wrappers currently shell out to `pnpm`, which is not installed in this container, so I ran the equivalent Bun workspace filters directly.
