### PR TITLE
feat(rules-nlp): add no-meaningless-modifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ export default defineConfig({
     'no-pronoun-led-claims': 'warn',
     'no-buzzword-stacks': 'warn',
     'no-vague-quantifiers': 'warn',
+    'no-meaningless-modifiers': 'warn',
   },
 })
 ```
@@ -104,6 +105,7 @@ Use a package-qualified ID if two loaded rulesets expose the same bare rule name
 | `@faircopy/rules-nlp/no-pronoun-led-claims` | Flag vague sentence openers like `This helps` and `It enables` |
 | `@faircopy/rules-nlp/no-buzzword-stacks` | Flag sentences overloaded with abstract benefit nouns |
 | `@faircopy/rules-nlp/no-vague-quantifiers` | Flag bare quantifiers without numeric anchors |
+| `@faircopy/rules-nlp/no-meaningless-modifiers` | Flag intensifiers like `very` and `obviously` that add no information |
 
 ## Packages
 

--- a/packages/rules-nlp/README.md
+++ b/packages/rules-nlp/README.md
@@ -23,6 +23,7 @@ rules: {
   'no-pronoun-led-claims': 'warn',
   'no-buzzword-stacks': 'warn',
   'no-vague-quantifiers': 'warn',
+  'no-meaningless-modifiers': 'warn',
 }
 ```
 
@@ -44,3 +45,4 @@ Package-qualified IDs like `@faircopy/rules-nlp/no-passive-voice` still work and
 | `no-pronoun-led-claims` | Flag vague sentence openers like `This helps` and `It enables` |
 | `no-buzzword-stacks` | Flag sentences overloaded with abstract benefit nouns |
 | `no-vague-quantifiers` | Flag bare quantifiers without numeric anchors |
+| `no-meaningless-modifiers` | Flag intensifiers like `very` and `obviously` that add no information |

--- a/packages/rules-nlp/src/index.ts
+++ b/packages/rules-nlp/src/index.ts
@@ -4,6 +4,7 @@ import { noExpletiveOpeners } from './no-expletive-openers.js'
 import { noFilterWords } from './no-filter-words.js'
 import { noEmptyTransformationClaims } from './no-empty-transformation-claims.js'
 import { noHedgeWords } from './no-hedge-words.js'
+import { noMeaninglessModifiers } from './no-meaningless-modifiers.js'
 import { noNominalizedPhrases } from './no-nominalized-phrases.js'
 import { noPassiveVoice } from './no-passive-voice.js'
 import { noPronounLedClaims } from './no-pronoun-led-claims.js'
@@ -17,6 +18,7 @@ export { noExpletiveOpeners } from './no-expletive-openers.js'
 export { noFilterWords } from './no-filter-words.js'
 export { noEmptyTransformationClaims } from './no-empty-transformation-claims.js'
 export { noHedgeWords } from './no-hedge-words.js'
+export { noMeaninglessModifiers } from './no-meaningless-modifiers.js'
 export { noNominalizedPhrases } from './no-nominalized-phrases.js'
 export { noPassiveVoice } from './no-passive-voice.js'
 export { noPronounLedClaims } from './no-pronoun-led-claims.js'
@@ -29,6 +31,7 @@ export type { NoExpletiveOpenersOptions } from './no-expletive-openers.js'
 export type { NoFilterWordsOptions } from './no-filter-words.js'
 export type { NoEmptyTransformationClaimsOptions } from './no-empty-transformation-claims.js'
 export type { NoHedgeWordsOptions } from './no-hedge-words.js'
+export type { NoMeaninglessModifiersOptions } from './no-meaningless-modifiers.js'
 export type { NoNominalizedPhrasesOptions } from './no-nominalized-phrases.js'
 export type { NoPassiveVoiceOptions } from './no-passive-voice.js'
 export type { NoPronounLedClaimsOptions } from './no-pronoun-led-claims.js'
@@ -44,6 +47,7 @@ export const ruleRegistry: Map<string, Rule> = new Map([
   ['no-expletive-openers', noExpletiveOpeners as Rule],
   ['no-filter-words', noFilterWords as Rule],
   ['no-hedge-words', noHedgeWords as Rule],
+  ['no-meaningless-modifiers', noMeaninglessModifiers as Rule],
   ['no-nominalized-phrases', noNominalizedPhrases as Rule],
   ['no-passive-voice', noPassiveVoice as Rule],
   ['no-pronoun-led-claims', noPronounLedClaims as Rule],

--- a/packages/rules-nlp/src/no-meaningless-modifiers.ts
+++ b/packages/rules-nlp/src/no-meaningless-modifiers.ts
@@ -1,0 +1,56 @@
+import type { Diagnostic, Rule, RuleInput } from '@faircopy/core'
+
+export interface NoMeaninglessModifiersOptions {
+  modifiers?: string[]
+}
+
+const DEFAULT_MODIFIERS = [
+  'very',
+  'really',
+  'actually',
+  'basically',
+  'literally',
+  'essentially',
+  'truly',
+  'definitely',
+  'clearly',
+  'obviously',
+]
+
+export const noMeaninglessModifiers: Rule<NoMeaninglessModifiersOptions> = {
+  id: 'no-meaningless-modifiers',
+  description: 'Flag intensifiers that add no information',
+  defaults: { modifiers: DEFAULT_MODIFIERS },
+  help: 'Meaningless modifiers inflate a claim without adding evidence. Delete the modifier, replace it with a concrete detail, or opt out specific words such as "clearly" and "obviously" when they are part of your voice.',
+
+  check({ text, sourceMap, options }: RuleInput<NoMeaninglessModifiersOptions>): Diagnostic[] {
+    const diagnostics: Diagnostic[] = []
+    const modifiers = options.modifiers?.length ? options.modifiers : DEFAULT_MODIFIERS
+
+    for (const modifier of modifiers) {
+      const re = new RegExp(`\\b${escapeRegExp(modifier).replace(/\\s+/g, '\\s+')}\\b`, 'gi')
+      let match: RegExpExecArray | null
+
+      while ((match = re.exec(text)) !== null) {
+        const matchedModifier = match[0]
+        const start = sourceMap[match.index]
+        const end = sourceMap[match.index + matchedModifier.length - 1]
+        if (start === undefined || end === undefined) continue
+
+        diagnostics.push({
+          ruleId: 'no-meaningless-modifiers',
+          severity: 'warn',
+          message: `remove meaningless modifier "${matchedModifier}"`,
+          range: { start, end: end + 1 },
+          help: noMeaninglessModifiers.help,
+        })
+      }
+    }
+
+    return diagnostics.sort((left, right) => left.range.start - right.range.start)
+  },
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}

--- a/packages/rules-nlp/test/rules.test.mjs
+++ b/packages/rules-nlp/test/rules.test.mjs
@@ -5,6 +5,7 @@ import {
   noEmptyTransformationClaims,
   noExpletiveOpeners,
   noHedgeWords,
+  noMeaninglessModifiers,
   noNominalizedPhrases,
   noPronounLedClaims,
   noRedundantPairs,
@@ -241,12 +242,44 @@ test('no-vague-quantifiers flags matching phrases mid-sentence', () => {
   assert.deepEqual(diagnostics[0].range, { start: 20, end: 27 })
 })
 
+test('no-meaningless-modifiers flags default intensifiers', () => {
+  const text = 'This is very fast and obviously better. It is really useful.'
+  const diagnostics = run(noMeaninglessModifiers, text)
+
+  assert.equal(diagnostics.length, 3)
+  assert.equal(diagnostics[0].ruleId, 'no-meaningless-modifiers')
+  assert.deepEqual(diagnostics.map(diagnostic => diagnostic.range), [
+    { start: 8, end: 12 },
+    { start: 22, end: 31 },
+    { start: 46, end: 52 },
+  ])
+})
+
+test('no-meaningless-modifiers supports custom modifier lists', () => {
+  const text = 'This is super fast and very stable.'
+  const diagnostics = run(noMeaninglessModifiers, text, {
+    modifiers: ['super'],
+  })
+
+  assert.equal(diagnostics.length, 1)
+  assert.match(diagnostics[0].message, /super/)
+})
+
+test('no-meaningless-modifiers matches modifiers mid-sentence', () => {
+  const text = 'The workflow is clearly faster after caching.'
+  const diagnostics = run(noMeaninglessModifiers, text)
+
+  assert.equal(diagnostics.length, 1)
+  assert.deepEqual(diagnostics[0].range, { start: 16, end: 23 })
+})
+
 test('rule registry exposes all nlp rules', () => {
   assert.ok(ruleRegistry.has('no-buzzword-stacks'))
   assert.ok(ruleRegistry.has('no-empty-transformation-claims'))
   assert.ok(ruleRegistry.has('no-expletive-openers'))
   assert.ok(ruleRegistry.has('no-filter-words'))
   assert.ok(ruleRegistry.has('no-hedge-words'))
+  assert.ok(ruleRegistry.has('no-meaningless-modifiers'))
   assert.ok(ruleRegistry.has('no-passive-voice'))
   assert.ok(ruleRegistry.has('no-pronoun-led-claims'))
   assert.ok(ruleRegistry.has('no-redundant-pairs'))


### PR DESCRIPTION
## Summary

- add `no-meaningless-modifiers` to `@faircopy/rules-nlp`
- expose the rule through exports, types, and the NLP registry
- document the rule in the root and package READMEs
- add focused coverage for defaults, custom modifiers, mid-sentence matches, and registry exposure

## Validation

- `bunx pnpm@9.15.9 install --frozen-lockfile`
- `CI=true bunx pnpm@9.15.9 build`
- `CI=true bunx pnpm@9.15.9 typecheck`
- `CI=true bunx pnpm@9.15.9 test`

## Risk

Low-to-medium: `clearly` and `obviously` can overlap with intentional assertion patterns. The default keeps them flagged, and teams can opt out through the `modifiers` option.
