### PR TITLE
feat(rules-nlp): add no-jargon rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ export default defineConfig({
     'no-expletive-openers': 'warn',
     'no-filter-words': 'warn',
     'no-hedge-words': 'warn',
+    'no-jargon': 'warn',
     'no-passive-voice': 'warn',
     'no-weak-modals': 'warn',
     'no-stacked-adjectives': 'warn',
@@ -98,6 +99,7 @@ Use a package-qualified ID if two loaded rulesets expose the same bare rule name
 | `@faircopy/rules-nlp/no-expletive-openers` | Flag sentence openings like `There are` |
 | `@faircopy/rules-nlp/no-filter-words` | Ban filter phrases like `I think` and `it seems` |
 | `@faircopy/rules-nlp/no-hedge-words` | Flag hedge words like `kind of` and `somewhat` |
+| `@faircopy/rules-nlp/no-jargon` | Flag business jargon like `leverage` and `circle back` |
 | `@faircopy/rules-nlp/no-passive-voice` | Flag likely passive-voice constructions |
 | `@faircopy/rules-nlp/no-weak-modals` | Flag hedged modal claims like `can help` and `might improve` |
 | `@faircopy/rules-nlp/no-stacked-adjectives` | Flag noun phrases with multiple adjectives before the noun |

--- a/packages/rules-nlp/README.md
+++ b/packages/rules-nlp/README.md
@@ -37,6 +37,7 @@ Package-qualified IDs like `@faircopy/rules-nlp/no-passive-voice` still work and
 | `no-expletive-openers` | Flag sentence openings like `There are` |
 | `no-filter-words` | Ban filter phrases like `I think` and `it seems` |
 | `no-hedge-words` | Flag hedge words like `kind of` and `somewhat` |
+| `no-jargon` | Flag business jargon like `leverage` and `circle back` |
 | `no-passive-voice` | Flag likely passive-voice constructions |
 | `no-redundant-pairs` | Flag redundant fixed phrases like `first and foremost` |
 | `no-weak-modals` | Flag hedged modal claims like `can help` and `might improve` |

--- a/packages/rules-nlp/src/index.ts
+++ b/packages/rules-nlp/src/index.ts
@@ -4,6 +4,7 @@ import { noExpletiveOpeners } from './no-expletive-openers.js'
 import { noFilterWords } from './no-filter-words.js'
 import { noEmptyTransformationClaims } from './no-empty-transformation-claims.js'
 import { noHedgeWords } from './no-hedge-words.js'
+import { noJargon } from './no-jargon.js'
 import { noMeaninglessModifiers } from './no-meaningless-modifiers.js'
 import { noNominalizedPhrases } from './no-nominalized-phrases.js'
 import { noPassiveVoice } from './no-passive-voice.js'
@@ -18,6 +19,7 @@ export { noExpletiveOpeners } from './no-expletive-openers.js'
 export { noFilterWords } from './no-filter-words.js'
 export { noEmptyTransformationClaims } from './no-empty-transformation-claims.js'
 export { noHedgeWords } from './no-hedge-words.js'
+export { noJargon } from './no-jargon.js'
 export { noMeaninglessModifiers } from './no-meaningless-modifiers.js'
 export { noNominalizedPhrases } from './no-nominalized-phrases.js'
 export { noPassiveVoice } from './no-passive-voice.js'
@@ -31,6 +33,7 @@ export type { NoExpletiveOpenersOptions } from './no-expletive-openers.js'
 export type { NoFilterWordsOptions } from './no-filter-words.js'
 export type { NoEmptyTransformationClaimsOptions } from './no-empty-transformation-claims.js'
 export type { NoHedgeWordsOptions } from './no-hedge-words.js'
+export type { NoJargonOptions } from './no-jargon.js'
 export type { NoMeaninglessModifiersOptions } from './no-meaningless-modifiers.js'
 export type { NoNominalizedPhrasesOptions } from './no-nominalized-phrases.js'
 export type { NoPassiveVoiceOptions } from './no-passive-voice.js'
@@ -47,6 +50,7 @@ export const ruleRegistry: Map<string, Rule> = new Map([
   ['no-expletive-openers', noExpletiveOpeners as Rule],
   ['no-filter-words', noFilterWords as Rule],
   ['no-hedge-words', noHedgeWords as Rule],
+  ['no-jargon', noJargon as Rule],
   ['no-meaningless-modifiers', noMeaninglessModifiers as Rule],
   ['no-nominalized-phrases', noNominalizedPhrases as Rule],
   ['no-passive-voice', noPassiveVoice as Rule],

--- a/packages/rules-nlp/src/no-jargon.ts
+++ b/packages/rules-nlp/src/no-jargon.ts
@@ -1,0 +1,55 @@
+import type { Diagnostic, Rule, RuleInput } from '@faircopy/core'
+
+export interface NoJargonOptions {
+  phrases?: string[]
+}
+
+const DEFAULT_PHRASES = [
+  'leverage',
+  'synergy',
+  'ideate',
+  'circle back',
+  'deep dive',
+  'drill down',
+  'move the needle',
+  'best of breed',
+  'best in class',
+]
+
+export const noJargon: Rule<NoJargonOptions> = {
+  id: 'no-jargon',
+  description: 'Flag business jargon and vague workplace idioms',
+  defaults: { phrases: DEFAULT_PHRASES },
+  help: 'Jargon makes copy sound generic. Replace it with the specific action, technical behavior, or customer outcome, or tune the phrase list for terms that are legitimate in your context.',
+
+  check({ text, sourceMap, options }: RuleInput<NoJargonOptions>): Diagnostic[] {
+    const diagnostics: Diagnostic[] = []
+    const phrases = options.phrases?.length ? options.phrases : DEFAULT_PHRASES
+
+    for (const phrase of phrases) {
+      const re = new RegExp(`\\b${escapeRegExp(phrase).replace(/\\s+/g, '\\s+')}\\b`, 'gi')
+      let match: RegExpExecArray | null
+
+      while ((match = re.exec(text)) !== null) {
+        const matchedPhrase = match[0]
+        const start = sourceMap[match.index]
+        const end = sourceMap[match.index + matchedPhrase.length - 1]
+        if (start === undefined || end === undefined) continue
+
+        diagnostics.push({
+          ruleId: 'no-jargon',
+          severity: 'warn',
+          message: `replace jargon phrase "${matchedPhrase}"`,
+          range: { start, end: end + 1 },
+          help: noJargon.help,
+        })
+      }
+    }
+
+    return diagnostics.sort((left, right) => left.range.start - right.range.start)
+  },
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}

--- a/packages/rules-nlp/test/rules.test.mjs
+++ b/packages/rules-nlp/test/rules.test.mjs
@@ -5,6 +5,7 @@ import {
   noEmptyTransformationClaims,
   noExpletiveOpeners,
   noHedgeWords,
+  noJargon,
   noMeaninglessModifiers,
   noNominalizedPhrases,
   noPronounLedClaims,
@@ -273,12 +274,45 @@ test('no-meaningless-modifiers matches modifiers mid-sentence', () => {
   assert.deepEqual(diagnostics[0].range, { start: 16, end: 23 })
 })
 
+test('no-jargon flags default business jargon phrases', () => {
+  const text = 'We leverage synergy, circle back, and move the needle.'
+  const diagnostics = run(noJargon, text)
+
+  assert.equal(diagnostics.length, 4)
+  assert.equal(diagnostics[0].ruleId, 'no-jargon')
+  assert.deepEqual(diagnostics.map(diagnostic => diagnostic.range), [
+    { start: 3, end: 11 },
+    { start: 12, end: 19 },
+    { start: 21, end: 32 },
+    { start: 38, end: 53 },
+  ])
+})
+
+test('no-jargon supports custom phrase lists', () => {
+  const text = 'We leverage data and boil the ocean later.'
+  const diagnostics = run(noJargon, text, {
+    phrases: ['boil the ocean'],
+  })
+
+  assert.equal(diagnostics.length, 1)
+  assert.match(diagnostics[0].message, /boil the ocean/)
+})
+
+test('no-jargon matches phrases mid-sentence', () => {
+  const text = 'The migration plan includes a deep dive after schema review.'
+  const diagnostics = run(noJargon, text)
+
+  assert.equal(diagnostics.length, 1)
+  assert.deepEqual(diagnostics[0].range, { start: 30, end: 39 })
+})
+
 test('rule registry exposes all nlp rules', () => {
   assert.ok(ruleRegistry.has('no-buzzword-stacks'))
   assert.ok(ruleRegistry.has('no-empty-transformation-claims'))
   assert.ok(ruleRegistry.has('no-expletive-openers'))
   assert.ok(ruleRegistry.has('no-filter-words'))
   assert.ok(ruleRegistry.has('no-hedge-words'))
+  assert.ok(ruleRegistry.has('no-jargon'))
   assert.ok(ruleRegistry.has('no-meaningless-modifiers'))
   assert.ok(ruleRegistry.has('no-passive-voice'))
   assert.ok(ruleRegistry.has('no-pronoun-led-claims'))


### PR DESCRIPTION
## Summary

- Add `no-jargon` to `@faircopy/rules-nlp` with configurable `phrases`.
- Register and export the rule from the NLP ruleset.
- Document the rule in the root and package README rule tables.

## Notes

The default list includes phrases from issue #14, including `deep dive` and `drill down`. Those can be valid in technical contexts, so the rule exposes `phrases` to let teams tune or replace the defaults.

Closes #14

## Verification

- `PATH="/tmp/faircopy-pnpm-bin:$PATH" pnpm build`
- `PATH="/tmp/faircopy-pnpm-bin:$PATH" pnpm --filter @faircopy/rules-nlp test`
- `PATH="/tmp/faircopy-pnpm-bin:$PATH" pnpm test`
- `PATH="/tmp/faircopy-pnpm-bin:$PATH" pnpm --config.dangerouslyAllowAllBuilds=true typecheck`
