### PR TITLE
feat(rules-nlp): add no-future-promises rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ export default defineConfig({
   rules: {
     'no-expletive-openers': 'warn',
     'no-filter-words': 'warn',
+    'no-future-promises': 'warn',
     'no-hedge-words': 'warn',
     'no-passive-voice': 'warn',
     'no-weak-modals': 'warn',
@@ -97,6 +98,7 @@ Use a package-qualified ID if two loaded rulesets expose the same bare rule name
 |---|---|
 | `@faircopy/rules-nlp/no-expletive-openers` | Flag sentence openings like `There are` |
 | `@faircopy/rules-nlp/no-filter-words` | Ban filter phrases like `I think` and `it seems` |
+| `@faircopy/rules-nlp/no-future-promises` | Flag future-tense promises like `will help you` |
 | `@faircopy/rules-nlp/no-hedge-words` | Flag hedge words like `kind of` and `somewhat` |
 | `@faircopy/rules-nlp/no-passive-voice` | Flag likely passive-voice constructions |
 | `@faircopy/rules-nlp/no-weak-modals` | Flag hedged modal claims like `can help` and `might improve` |

--- a/packages/rules-nlp/README.md
+++ b/packages/rules-nlp/README.md
@@ -13,6 +13,7 @@ rulesets: ['@faircopy/rules-nlp'],
 rules: {
   'no-expletive-openers': 'warn',
   'no-filter-words': 'warn',
+  'no-future-promises': 'warn',
   'no-hedge-words': 'warn',
   'no-empty-transformation-claims': 'warn',
   'no-passive-voice': 'warn',
@@ -36,6 +37,7 @@ Package-qualified IDs like `@faircopy/rules-nlp/no-passive-voice` still work and
 | `no-empty-transformation-claims` | Flag broad transformation cliches like `transform the way teams work` |
 | `no-expletive-openers` | Flag sentence openings like `There are` |
 | `no-filter-words` | Ban filter phrases like `I think` and `it seems` |
+| `no-future-promises` | Flag future-tense promises like `will help you` |
 | `no-hedge-words` | Flag hedge words like `kind of` and `somewhat` |
 | `no-passive-voice` | Flag likely passive-voice constructions |
 | `no-redundant-pairs` | Flag redundant fixed phrases like `first and foremost` |

--- a/packages/rules-nlp/src/index.ts
+++ b/packages/rules-nlp/src/index.ts
@@ -3,6 +3,7 @@ import { noBuzzwordStacks } from './no-buzzword-stacks.js'
 import { noExpletiveOpeners } from './no-expletive-openers.js'
 import { noFilterWords } from './no-filter-words.js'
 import { noEmptyTransformationClaims } from './no-empty-transformation-claims.js'
+import { noFuturePromises } from './no-future-promises.js'
 import { noHedgeWords } from './no-hedge-words.js'
 import { noMeaninglessModifiers } from './no-meaningless-modifiers.js'
 import { noNominalizedPhrases } from './no-nominalized-phrases.js'
@@ -17,6 +18,7 @@ export { noBuzzwordStacks } from './no-buzzword-stacks.js'
 export { noExpletiveOpeners } from './no-expletive-openers.js'
 export { noFilterWords } from './no-filter-words.js'
 export { noEmptyTransformationClaims } from './no-empty-transformation-claims.js'
+export { noFuturePromises } from './no-future-promises.js'
 export { noHedgeWords } from './no-hedge-words.js'
 export { noMeaninglessModifiers } from './no-meaningless-modifiers.js'
 export { noNominalizedPhrases } from './no-nominalized-phrases.js'
@@ -30,6 +32,7 @@ export type { NoBuzzwordStacksOptions } from './no-buzzword-stacks.js'
 export type { NoExpletiveOpenersOptions } from './no-expletive-openers.js'
 export type { NoFilterWordsOptions } from './no-filter-words.js'
 export type { NoEmptyTransformationClaimsOptions } from './no-empty-transformation-claims.js'
+export type { NoFuturePromisesOptions } from './no-future-promises.js'
 export type { NoHedgeWordsOptions } from './no-hedge-words.js'
 export type { NoMeaninglessModifiersOptions } from './no-meaningless-modifiers.js'
 export type { NoNominalizedPhrasesOptions } from './no-nominalized-phrases.js'
@@ -46,6 +49,7 @@ export const ruleRegistry: Map<string, Rule> = new Map([
   ['no-empty-transformation-claims', noEmptyTransformationClaims as Rule],
   ['no-expletive-openers', noExpletiveOpeners as Rule],
   ['no-filter-words', noFilterWords as Rule],
+  ['no-future-promises', noFuturePromises as Rule],
   ['no-hedge-words', noHedgeWords as Rule],
   ['no-meaningless-modifiers', noMeaninglessModifiers as Rule],
   ['no-nominalized-phrases', noNominalizedPhrases as Rule],

--- a/packages/rules-nlp/src/no-future-promises.ts
+++ b/packages/rules-nlp/src/no-future-promises.ts
@@ -1,0 +1,51 @@
+import type { Diagnostic, Rule, RuleInput } from '@faircopy/core'
+
+export interface NoFuturePromisesOptions {
+  phrases?: string[]
+}
+
+const DEFAULT_PHRASES = [
+  'will help you',
+  'will enable',
+  'will transform',
+  'will allow you to',
+  'will empower',
+]
+
+export const noFuturePromises: Rule<NoFuturePromisesOptions> = {
+  id: 'no-future-promises',
+  description: 'Flag future-tense promises without present evidence',
+  defaults: { phrases: DEFAULT_PHRASES },
+  help: 'Future promises defer proof. Rewrite the claim around current behavior, concrete evidence, or a specific outcome already available.',
+
+  check({ text, sourceMap, options }: RuleInput<NoFuturePromisesOptions>): Diagnostic[] {
+    const diagnostics: Diagnostic[] = []
+    const phrases = options.phrases?.length ? options.phrases : DEFAULT_PHRASES
+
+    for (const phrase of phrases) {
+      const re = new RegExp(`\\b${escapeRegExp(phrase).replace(/\\s+/g, '\\s+')}\\b`, 'gi')
+      let match: RegExpExecArray | null
+
+      while ((match = re.exec(text)) !== null) {
+        const matchedPhrase = match[0]
+        const start = sourceMap[match.index]
+        const end = sourceMap[match.index + matchedPhrase.length - 1]
+        if (start === undefined || end === undefined) continue
+
+        diagnostics.push({
+          ruleId: 'no-future-promises',
+          severity: 'warn',
+          message: `replace future promise "${matchedPhrase}" with present evidence`,
+          range: { start, end: end + 1 },
+          help: noFuturePromises.help,
+        })
+      }
+    }
+
+    return diagnostics.sort((left, right) => left.range.start - right.range.start)
+  },
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}

--- a/packages/rules-nlp/test/rules.test.mjs
+++ b/packages/rules-nlp/test/rules.test.mjs
@@ -4,6 +4,7 @@ import {
   noBuzzwordStacks,
   noEmptyTransformationClaims,
   noExpletiveOpeners,
+  noFuturePromises,
   noHedgeWords,
   noMeaninglessModifiers,
   noNominalizedPhrases,
@@ -273,11 +274,42 @@ test('no-meaningless-modifiers matches modifiers mid-sentence', () => {
   assert.deepEqual(diagnostics[0].range, { start: 16, end: 23 })
 })
 
+test('no-future-promises flags default future-tense promises', () => {
+  const text = 'Faircopy will help you write faster and will enable cleaner launches.'
+  const diagnostics = run(noFuturePromises, text)
+
+  assert.equal(diagnostics.length, 2)
+  assert.equal(diagnostics[0].ruleId, 'no-future-promises')
+  assert.deepEqual(diagnostics.map(diagnostic => diagnostic.range), [
+    { start: 9, end: 22 },
+    { start: 40, end: 51 },
+  ])
+})
+
+test('no-future-promises supports custom phrase lists', () => {
+  const text = 'The assistant will streamline approvals and will help you ship.'
+  const diagnostics = run(noFuturePromises, text, {
+    phrases: ['will streamline'],
+  })
+
+  assert.equal(diagnostics.length, 1)
+  assert.match(diagnostics[0].message, /will streamline/)
+})
+
+test('no-future-promises matches phrases mid-sentence', () => {
+  const text = 'The onboarding checklist will allow you to launch without rewriting copy.'
+  const diagnostics = run(noFuturePromises, text)
+
+  assert.equal(diagnostics.length, 1)
+  assert.deepEqual(diagnostics[0].range, { start: 25, end: 42 })
+})
+
 test('rule registry exposes all nlp rules', () => {
   assert.ok(ruleRegistry.has('no-buzzword-stacks'))
   assert.ok(ruleRegistry.has('no-empty-transformation-claims'))
   assert.ok(ruleRegistry.has('no-expletive-openers'))
   assert.ok(ruleRegistry.has('no-filter-words'))
+  assert.ok(ruleRegistry.has('no-future-promises'))
   assert.ok(ruleRegistry.has('no-hedge-words'))
   assert.ok(ruleRegistry.has('no-meaningless-modifiers'))
   assert.ok(ruleRegistry.has('no-passive-voice'))


### PR DESCRIPTION
## Summary

- Adds the `no-future-promises` NLP rule for future-tense promise phrases like `will help you`, `will enable`, and `will transform`.
- Wires the rule into the NLP registry, public exports, README tables, and focused rule tests.
- Keeps the phrase list configurable through the `phrases` option for teams that want different promise patterns.

Closes #15.

## Validation

- `bunx pnpm@9.15.9 --workspace-concurrency=1 build`
- `bunx pnpm@9.15.9 --filter @faircopy/rules-nlp test`
- `bunx pnpm@9.15.9 --workspace-concurrency=1 test`
- `bunx pnpm@9.15.9 --workspace-concurrency=1 typecheck`
