### PR TITLE
feat(rules-nlp): add no-superlative-claims rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ export default defineConfig({
     'no-buzzword-stacks': 'warn',
     'no-vague-quantifiers': 'warn',
     'no-meaningless-modifiers': 'warn',
+    'no-superlative-claims': 'warn',
   },
 })
 ```
@@ -106,6 +107,7 @@ Use a package-qualified ID if two loaded rulesets expose the same bare rule name
 | `@faircopy/rules-nlp/no-buzzword-stacks` | Flag sentences overloaded with abstract benefit nouns |
 | `@faircopy/rules-nlp/no-vague-quantifiers` | Flag bare quantifiers without numeric anchors |
 | `@faircopy/rules-nlp/no-meaningless-modifiers` | Flag intensifiers like `very` and `obviously` that add no information |
+| `@faircopy/rules-nlp/no-superlative-claims` | Flag unproven superlatives like `best` and `world-class` |
 
 ## Packages
 

--- a/packages/rules-nlp/README.md
+++ b/packages/rules-nlp/README.md
@@ -24,6 +24,7 @@ rules: {
   'no-buzzword-stacks': 'warn',
   'no-vague-quantifiers': 'warn',
   'no-meaningless-modifiers': 'warn',
+  'no-superlative-claims': 'warn',
 }
 ```
 
@@ -46,3 +47,4 @@ Package-qualified IDs like `@faircopy/rules-nlp/no-passive-voice` still work and
 | `no-buzzword-stacks` | Flag sentences overloaded with abstract benefit nouns |
 | `no-vague-quantifiers` | Flag bare quantifiers without numeric anchors |
 | `no-meaningless-modifiers` | Flag intensifiers like `very` and `obviously` that add no information |
+| `no-superlative-claims` | Flag unproven superlatives like `best` and `world-class` |

--- a/packages/rules-nlp/src/index.ts
+++ b/packages/rules-nlp/src/index.ts
@@ -10,6 +10,7 @@ import { noPassiveVoice } from './no-passive-voice.js'
 import { noPronounLedClaims } from './no-pronoun-led-claims.js'
 import { noRedundantPairs } from './no-redundant-pairs.js'
 import { noStackedAdjectives } from './no-stacked-adjectives.js'
+import { noSuperlativeClaims } from './no-superlative-claims.js'
 import { noVagueQuantifiers } from './no-vague-quantifiers.js'
 import { noWeakModals } from './no-weak-modals.js'
 
@@ -24,6 +25,7 @@ export { noPassiveVoice } from './no-passive-voice.js'
 export { noPronounLedClaims } from './no-pronoun-led-claims.js'
 export { noRedundantPairs } from './no-redundant-pairs.js'
 export { noStackedAdjectives } from './no-stacked-adjectives.js'
+export { noSuperlativeClaims } from './no-superlative-claims.js'
 export { noVagueQuantifiers } from './no-vague-quantifiers.js'
 export { noWeakModals } from './no-weak-modals.js'
 export type { NoBuzzwordStacksOptions } from './no-buzzword-stacks.js'
@@ -37,6 +39,7 @@ export type { NoPassiveVoiceOptions } from './no-passive-voice.js'
 export type { NoPronounLedClaimsOptions } from './no-pronoun-led-claims.js'
 export type { NoRedundantPairsOptions } from './no-redundant-pairs.js'
 export type { NoStackedAdjectivesOptions } from './no-stacked-adjectives.js'
+export type { NoSuperlativeClaimsOptions } from './no-superlative-claims.js'
 export type { NoVagueQuantifiersOptions } from './no-vague-quantifiers.js'
 export type { NoWeakModalsOptions } from './no-weak-modals.js'
 
@@ -53,6 +56,7 @@ export const ruleRegistry: Map<string, Rule> = new Map([
   ['no-pronoun-led-claims', noPronounLedClaims as Rule],
   ['no-redundant-pairs', noRedundantPairs as Rule],
   ['no-stacked-adjectives', noStackedAdjectives as Rule],
+  ['no-superlative-claims', noSuperlativeClaims as Rule],
   ['no-vague-quantifiers', noVagueQuantifiers as Rule],
   ['no-weak-modals', noWeakModals as Rule],
 ])

--- a/packages/rules-nlp/src/no-superlative-claims.ts
+++ b/packages/rules-nlp/src/no-superlative-claims.ts
@@ -24,7 +24,10 @@ export const noSuperlativeClaims: Rule<NoSuperlativeClaimsOptions> = {
 
   check({ text, sourceMap, options }: RuleInput<NoSuperlativeClaimsOptions>): Diagnostic[] {
     const diagnostics: Diagnostic[] = []
-    const phrases = options.phrases?.length ? options.phrases : DEFAULT_PHRASES
+    const phrases = getLongestPhrasesFirst(
+      options.phrases?.length ? options.phrases : DEFAULT_PHRASES
+    )
+    const claimedRanges: Array<{ start: number; end: number }> = []
 
     for (const phrase of phrases) {
       const re = new RegExp(`\\b${escapeRegExp(phrase).replace(/\\s+/g, '\\s+')}\\b`, 'gi')
@@ -32,9 +35,14 @@ export const noSuperlativeClaims: Rule<NoSuperlativeClaimsOptions> = {
 
       while ((match = re.exec(text)) !== null) {
         const matchedPhrase = match[0]
+        const matchStart = match.index
+        const matchEnd = match.index + matchedPhrase.length
+        if (claimedRanges.some(range => rangesOverlap(range, matchStart, matchEnd))) continue
+
         const start = sourceMap[match.index]
         const end = sourceMap[match.index + matchedPhrase.length - 1]
         if (start === undefined || end === undefined) continue
+        claimedRanges.push({ start: matchStart, end: matchEnd })
 
         diagnostics.push({
           ruleId: 'no-superlative-claims',
@@ -48,6 +56,14 @@ export const noSuperlativeClaims: Rule<NoSuperlativeClaimsOptions> = {
 
     return diagnostics.sort((left, right) => left.range.start - right.range.start)
   },
+}
+
+function getLongestPhrasesFirst(phrases: string[]): string[] {
+  return [...phrases].sort((left, right) => right.length - left.length)
+}
+
+function rangesOverlap(range: { start: number; end: number }, start: number, end: number): boolean {
+  return start < range.end && end > range.start
 }
 
 function escapeRegExp(value: string): string {

--- a/packages/rules-nlp/src/no-superlative-claims.ts
+++ b/packages/rules-nlp/src/no-superlative-claims.ts
@@ -1,0 +1,55 @@
+import type { Diagnostic, Rule, RuleInput } from '@faircopy/core'
+
+export interface NoSuperlativeClaimsOptions {
+  phrases?: string[]
+}
+
+const DEFAULT_PHRASES = [
+  'best',
+  'leading',
+  'world-class',
+  'top',
+  'premier',
+  'ultimate',
+  'industry-leading',
+  'cutting-edge',
+  'state-of-the-art',
+]
+
+export const noSuperlativeClaims: Rule<NoSuperlativeClaimsOptions> = {
+  id: 'no-superlative-claims',
+  description: 'Flag unproven superlatives and market-positioning claims',
+  defaults: { phrases: DEFAULT_PHRASES },
+  help: 'Superlative claims need proof. Replace broad market-positioning words with evidence, scope, or a concrete product behavior.',
+
+  check({ text, sourceMap, options }: RuleInput<NoSuperlativeClaimsOptions>): Diagnostic[] {
+    const diagnostics: Diagnostic[] = []
+    const phrases = options.phrases?.length ? options.phrases : DEFAULT_PHRASES
+
+    for (const phrase of phrases) {
+      const re = new RegExp(`\\b${escapeRegExp(phrase).replace(/\\s+/g, '\\s+')}\\b`, 'gi')
+      let match: RegExpExecArray | null
+
+      while ((match = re.exec(text)) !== null) {
+        const matchedPhrase = match[0]
+        const start = sourceMap[match.index]
+        const end = sourceMap[match.index + matchedPhrase.length - 1]
+        if (start === undefined || end === undefined) continue
+
+        diagnostics.push({
+          ruleId: 'no-superlative-claims',
+          severity: 'warn',
+          message: `prove or remove superlative claim "${matchedPhrase.toLowerCase()}"`,
+          range: { start, end: end + 1 },
+          help: noSuperlativeClaims.help,
+        })
+      }
+    }
+
+    return diagnostics.sort((left, right) => left.range.start - right.range.start)
+  },
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}

--- a/packages/rules-nlp/test/rules.test.mjs
+++ b/packages/rules-nlp/test/rules.test.mjs
@@ -307,6 +307,15 @@ test('no-superlative-claims matches phrases mid-sentence', () => {
   assert.deepEqual(diagnostics[0].range, { start: 16, end: 28 })
 })
 
+test('no-superlative-claims prefers longer overlapping phrases', () => {
+  const text = 'The workflow is industry-leading after caching.'
+  const diagnostics = run(noSuperlativeClaims, text)
+
+  assert.equal(diagnostics.length, 1)
+  assert.equal(diagnostics[0].message, 'prove or remove superlative claim "industry-leading"')
+  assert.deepEqual(diagnostics[0].range, { start: 16, end: 32 })
+})
+
 test('no-superlative-claims does not match substrings inside longer words', () => {
   const text = 'The topology page mentions bestowed access and premiere support.'
   const diagnostics = run(noSuperlativeClaims, text)

--- a/packages/rules-nlp/test/rules.test.mjs
+++ b/packages/rules-nlp/test/rules.test.mjs
@@ -10,6 +10,7 @@ import {
   noPronounLedClaims,
   noRedundantPairs,
   noStackedAdjectives,
+  noSuperlativeClaims,
   noVagueQuantifiers,
   noWeakModals,
   ruleRegistry,
@@ -273,6 +274,44 @@ test('no-meaningless-modifiers matches modifiers mid-sentence', () => {
   assert.deepEqual(diagnostics[0].range, { start: 16, end: 23 })
 })
 
+test('no-superlative-claims flags default superlatives', () => {
+  const text = 'The best world-class platform uses state-of-the-art review.'
+  const diagnostics = run(noSuperlativeClaims, text)
+
+  assert.equal(diagnostics.length, 3)
+  assert.equal(diagnostics[0].ruleId, 'no-superlative-claims')
+  assert.deepEqual(diagnostics.map(diagnostic => diagnostic.range), [
+    { start: 4, end: 8 },
+    { start: 9, end: 20 },
+    { start: 35, end: 51 },
+  ])
+})
+
+test('no-superlative-claims supports custom phrase lists', () => {
+  const text = 'The gold standard workflow is the best option.'
+  const diagnostics = run(noSuperlativeClaims, text, {
+    phrases: ['gold standard'],
+  })
+
+  assert.equal(diagnostics.length, 1)
+  assert.match(diagnostics[0].message, /gold standard/)
+})
+
+test('no-superlative-claims matches phrases mid-sentence', () => {
+  const text = 'The workflow is cutting-edge after caching.'
+  const diagnostics = run(noSuperlativeClaims, text)
+
+  assert.equal(diagnostics.length, 1)
+  assert.deepEqual(diagnostics[0].range, { start: 16, end: 28 })
+})
+
+test('no-superlative-claims does not match substrings inside longer words', () => {
+  const text = 'The topology page mentions bestowed access and premiere support.'
+  const diagnostics = run(noSuperlativeClaims, text)
+
+  assert.equal(diagnostics.length, 0)
+})
+
 test('rule registry exposes all nlp rules', () => {
   assert.ok(ruleRegistry.has('no-buzzword-stacks'))
   assert.ok(ruleRegistry.has('no-empty-transformation-claims'))
@@ -285,6 +324,7 @@ test('rule registry exposes all nlp rules', () => {
   assert.ok(ruleRegistry.has('no-redundant-pairs'))
   assert.ok(ruleRegistry.has('no-weak-modals'))
   assert.ok(ruleRegistry.has('no-stacked-adjectives'))
+  assert.ok(ruleRegistry.has('no-superlative-claims'))
   assert.ok(ruleRegistry.has('no-nominalized-phrases'))
   assert.ok(ruleRegistry.has('no-vague-quantifiers'))
 })


### PR DESCRIPTION
## Summary

- Add `no-superlative-claims` to `@faircopy/rules-nlp`
- Wire the rule through exports, type exports, and the NLP rule registry
- Document the rule in the root README and `packages/rules-nlp/README.md`
- Cover defaults, custom `phrases`, mid-sentence matching, substring boundaries, and registry exposure

Closes #16.

## Notes

- The default phrase list follows issue #16: `best`, `leading`, `world-class`, `top`, `premier`, `ultimate`, `industry-leading`, `cutting-edge`, and `state-of-the-art`
- Ambiguous terms like `top` and `leading` are configurable through `phrases`, so teams can tune legitimate layout or verb usage out of the rule
- This branch includes current `origin/main` after PR #21 and PR #22 landed

## Validation

- `CI=true bunx pnpm@9.15.9 --workspace-concurrency=1 build`
- `CI=true bunx pnpm@9.15.9 --filter @faircopy/rules-nlp test`
- `CI=true bunx pnpm@9.15.9 --workspace-concurrency=1 test`
- `CI=true bunx pnpm@9.15.9 --workspace-concurrency=1 typecheck`
