### PR TITLE
feat(core): add ignore comment directives

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -23,6 +23,26 @@ const { config, configPath } = await loadConfig(process.cwd())
 
 Resolves file globs from `config.files`, respecting `config.ignore` and `.gitignore`.
 
+## Ignore comments
+
+Suppress every rule for one source line with either directive:
+
+```tsx
+// faircopy-ignore-next-line
+<p>Intentional copy that would otherwise be reported.</p>
+
+<p>Intentional copy.</p> {/* faircopy-ignore-line */}
+```
+
+Add comma-separated rule IDs to suppress only those rules:
+
+```tsx
+// faircopy-ignore-next-line no-em-dash, no-weasel-words
+<p>Intentional rule exceptions.</p>
+```
+
+The directives work with line, block, JSX, and HTML comment markers.
+
 ```ts
 import { resolveFiles } from '@faircopy/core'
 const files = await resolveFiles(config, cwd)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,7 +21,7 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit",
-    "test": "echo 'no tests yet'",
+    "test": "node --test test/*.test.mjs",
     "prepublishOnly": "pnpm run build"
   },
   "dependencies": {

--- a/packages/core/src/runner.ts
+++ b/packages/core/src/runner.ts
@@ -26,6 +26,7 @@ export async function lintFile(
   if (!adapter) return []
 
   const extractions = await adapter.extract(filePath, source)
+  const ignoredLines = collectIgnoredLines(source)
   const diagnostics: Diagnostic[] = []
 
   for (const extraction of extractions) {
@@ -39,10 +40,41 @@ export async function lintFile(
         meta: extraction.meta,
       })
       for (const diag of results) {
+        const line = lineAtOffset(source, diag.range.start)
+        const ignoredRules = ignoredLines.get(line)
+        if (ignoredRules?.has('*') || ignoredRules?.has(diag.ruleId)) continue
         diagnostics.push({ ...diag, severity })
       }
     }
   }
 
   return diagnostics
+}
+
+function collectIgnoredLines(source: string): Map<number, Set<string>> {
+  const ignored = new Map<number, Set<string>>()
+  const lines = source.split(/\r?\n/)
+
+  lines.forEach((line, index) => {
+    const directive = line.match(
+      /(?:\/\/|\/\*+|\*|<!--|\{\/\*)\s*faircopy-ignore-(line|next-line)(?:\s+([\w-]+(?:\s*,\s*[\w-]+)*))?/,
+    )
+    if (!directive) return
+
+    const targetLine = index + (directive[1] === 'next-line' ? 2 : 1)
+    const rules = directive[2]?.split(',').map(rule => rule.trim()) ?? ['*']
+    const existing = ignored.get(targetLine) ?? new Set<string>()
+    rules.forEach(rule => existing.add(rule))
+    ignored.set(targetLine, existing)
+  })
+
+  return ignored
+}
+
+function lineAtOffset(source: string, offset: number): number {
+  let line = 1
+  for (let index = 0; index < offset; index++) {
+    if (source[index] === '\n') line++
+  }
+  return line
 }

--- a/packages/core/test/ignore-comments.test.mjs
+++ b/packages/core/test/ignore-comments.test.mjs
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { lintFile } from '../dist/index.js'
+
+const adapter = {
+  name: 'fixture',
+  extensions: ['.tsx'],
+  async extract(_filePath, source) {
+    return [...source.matchAll(/copy:\s*(.+)$/gm)].map(match => ({
+      text: match[1],
+      sourceMap: Array.from(
+        { length: match[1].length },
+        (_, index) => match.index + match[0].indexOf(match[1]) + index,
+      ),
+    }))
+  },
+}
+
+const rules = [
+  {
+    severity: 'error',
+    options: {},
+    rule: {
+      id: 'no-bad-copy',
+      description: 'fixture rule',
+      check({ text, sourceMap }) {
+        if (!text.includes('bad')) return []
+        return [{
+          ruleId: 'no-bad-copy',
+          severity: 'error',
+          message: 'bad copy',
+          range: { start: sourceMap[0], end: sourceMap.at(-1) + 1 },
+        }]
+      },
+    },
+  },
+]
+
+test('faircopy-ignore-next-line suppresses all rules on the following line', async () => {
+  const source = [
+    'copy: bad unsuppressed',
+    '// faircopy-ignore-next-line',
+    'copy: bad suppressed',
+  ].join('\n')
+
+  const diagnostics = await lintFile('fixture.tsx', source, [adapter], rules)
+
+  assert.equal(diagnostics.length, 1)
+  assert.equal(source.slice(diagnostics[0].range.start, diagnostics[0].range.end), 'bad unsuppressed')
+})
+
+test('faircopy-ignore-line suppresses the directive line', async () => {
+  const source = 'copy: bad suppressed // faircopy-ignore-line'
+
+  const diagnostics = await lintFile('fixture.tsx', source, [adapter], rules)
+
+  assert.deepEqual(diagnostics, [])
+})
+
+test('rule-specific directives leave other rules enabled', async () => {
+  const otherRule = {
+    ...rules[0],
+    rule: {
+      ...rules[0].rule,
+      id: 'other-rule',
+      check(input) {
+        return rules[0].rule.check(input).map(diagnostic => ({
+          ...diagnostic,
+          ruleId: 'other-rule',
+        }))
+      },
+    },
+  }
+  const source = [
+    '// faircopy-ignore-next-line no-bad-copy',
+    'copy: bad copy',
+  ].join('\n')
+
+  const diagnostics = await lintFile('fixture.tsx', source, [adapter], [rules[0], otherRule])
+
+  assert.deepEqual(diagnostics.map(diagnostic => diagnostic.ruleId), ['other-rule'])
+})


### PR DESCRIPTION
## Summary

Add source comment directives for intentional Faircopy exceptions across every adapter. Suppression lives in the core runner, so Solid, React, Astro, and future adapters share the same behavior.

## Changes

- support `faircopy-ignore-line` and `faircopy-ignore-next-line`
- support optional comma-separated rule IDs for narrow suppressions
- document line, block, JSX, and HTML comment usage
- add core regression coverage for line, next-line, and rule-specific behavior

## Test plan

- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm test`
